### PR TITLE
Regenerate lock file and requirements freeze

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -95,24 +95,24 @@
         },
         "cftime": {
             "hashes": [
-                "sha256:106d8bd1c144c83de1288c51225fd6846539074b60bb9e05b5e357d5e1eed6b9",
-                "sha256:3fb1f637aed7391c9a5d718175014f4cf705970e1d596bbc80bcac078eefefb0",
-                "sha256:555c101a0d03f6f6231253d0d84620a5ffb69757680be532086a70b033b9969b",
-                "sha256:623255e0264de5cde085f0027ab03365965f3f416de407b604b00abe676f20f2",
-                "sha256:7c4d0de4ab846b76f73a9a45d9085e5c6321610e74548bdeaaf6c588fe841587",
-                "sha256:8c9b27142cbd41049346128c8a5b78d292b675a3c185e16ed58645c273156e16",
-                "sha256:9ad8521598be2b354d159538e9572afb4c0d4ac2b0b6240eef7197e1d709a89e",
-                "sha256:9e1c863e38d410de0b59c5be7799ef05cd6f241cc254c6d656dfdae7546c1025",
-                "sha256:ad0b9db793eae28ed1f53157e87044119c8153bf211420414f2c6b6e27fc86db",
-                "sha256:bdd3a0b85fda45585529825e0954d6140d6df40b7bc489770e72fa6ce79ab9ea",
-                "sha256:d65d0fcc7120db05ddd34625310bc56038063fddcf63f3129379949d2ee762e9",
-                "sha256:dd44afef96467f2cb3ec9324e9f471653e5daa55b05198f8da389ccb85d38157",
-                "sha256:eab0fb0268fc4743f65eb6efac5998af2b0805d914c2e2f83226531add57fd98",
-                "sha256:ead81301dbfcfef2b452ce6997f4f82cc0c2d968d27a2795251b5cdfc4b17295",
-                "sha256:fb9a5ed38dee8ac43235ba161bf5fb61274e965b9b396a650ba4d515b9d70a7c",
-                "sha256:fd84b8631dca1db9b40a75e18671b9edafd3515580d8ab33ce1ebafee75451f0"
+                "sha256:478b4f20b3b62a5feae6b186bf43690b2c8ea8df20d36a2b4301c1ec018cd5f6",
+                "sha256:4d20b09b33c2516ff6c09a812cf657159d0f4a7a0baf5f5a5da1e780d7b00905",
+                "sha256:51a72fbb202c7dc68be871607688b53d42c766bbc46a2847d57bb5c23bc4ba03",
+                "sha256:5d5f04ae796a41def559c5023e4a4a65b3150ccf89176902a9707f696407ec0f",
+                "sha256:6033688568622a77614fc06329c05e2a7e2716f2ed298b3747a71f8fe7b99e23",
+                "sha256:66c127f4c69a96565a56cf850039c6f89028607ab2f9aae13a6865c6270bf8de",
+                "sha256:85e5f5fdbaeeacd9bb14a9ef063bf28afb1a22d1c2a0609073d1ef3c3782d4e9",
+                "sha256:a3325f063fc4e81a1b415474e57be37810212bae42e0f7125b931e6a0ac6a445",
+                "sha256:a91e213590dad45574f5f6560aee3bd89bea6f02c954c04d15e5f38b874b0b4f",
+                "sha256:abd3c113fc162c7ec7158274d8af8e6961e8933ce00444961eb4a2fac9a5ee38",
+                "sha256:b18c75c073399d6e01adb7e471ad2baf409d23968767c8defa076c8b6b014f95",
+                "sha256:c1e1eeeaebbb2178e23aae3b9aa04c7fcf4993b79ac5bc378e989951828af262",
+                "sha256:d5bf8d5c9097dc27fcfd5b183025f8ce556d8986a402f838b9c1707249d5df6d",
+                "sha256:d8ab191278b975fd2655c0774e5ba89bf59c5c414bfccc000396a61cadacc382",
+                "sha256:ddecde86c6b70893dcb055666eafd1403d660b7861200e2c2948ae32f9c0397a",
+                "sha256:ff0a175edda260357ff7d24a32bbe0a8c72eafd5f6a404ce487127f9d01836db"
             ],
-            "version": "==1.1.3"
+            "version": "==1.2.0"
         },
         "chardet": {
             "hashes": [
@@ -268,22 +268,25 @@
         },
         "kiwisolver": {
             "hashes": [
-                "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c",
-                "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd",
-                "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f",
-                "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74",
                 "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1",
-                "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c",
-                "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec",
+                "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f",
+                "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8",
+                "sha256:be046da49fbc3aa9491cc7296db7e8d27bcf0c3d5d1a40259c10471b014e4e0c",
+                "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd",
+                "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e",
+                "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2",
+                "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74",
                 "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b",
+                "sha256:63f55f490b958b6299e4e5bdac66ac988c3d11b7fafa522800359075d4fa56d1",
                 "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7",
+                "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657",
+                "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c",
+                "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c",
                 "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113",
                 "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec",
-                "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf",
-                "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e",
-                "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657",
-                "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8",
-                "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"
+                "sha256:38d05c9ecb24eee1246391820ed7137ac42a50209c203c908154782fced90e44",
+                "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec",
+                "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf"
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.2.0"
@@ -548,7 +551,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pyproj": {
@@ -677,7 +680,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "tornado": {

--- a/requirements_freeze.txt
+++ b/requirements_freeze.txt
@@ -1,10 +1,9 @@
-atomicwrites==1.4.0
 attrs==19.3.0
 bcrypt==3.1.7
 bokeh==2.0.2
 certifi==2020.6.20
 cffi==1.14.0
-cftime==1.1.3
+cftime==1.2.0
 chardet==3.0.4
 click==7.1.2
 cryptography==2.9.2


### PR DESCRIPTION
**Purpose** - The lock/freeze files are slightly outdated, namely `atomicwrites` is not needed by current version of `pytest`
**What it does** - I regenerated these in a new virtualenv based on latest state of powersimdata. Following commands for reference:
```
# in fish shell
# tell pipenv to create virtualenv at (pwd)/.venv/ 
set -x PIPENV_VENV_IN_PROJECT "1"

# regenerate lock file, by resolving dependencies in Pipfile
pipenv lock

# install from lock file, since it exists
pipenv install

# activate virtualenv, to access pip
pipenv shell

# update freeze as well
pip freeze > requirements_freeze.txt

# in requirements_freeze.txt, replace the autogenerated powersimdata with `../PowerSimData`, since it tries to use the git repo instead of path
```
**Time to review** - 3 mins