### PR TITLE
chore: fix outdated repo in ci-test.yml

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout PowerSimData
         uses: actions/checkout@v2
         with:
-          repository: intvenlab/PowerSimData
+          repository: Breakthrough-Energy/PowerSimData
           token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PowerSimData
 


### PR DESCRIPTION
Think this one is pretty self explanatory. Somehow it wasn't broken, but tests still pass so that means the secret token is still good.