### PR TITLE
ci: use black profile for isort

### DIFF
--- a/prereise/gather/demanddata/nrel_efs/map_states.py
+++ b/prereise/gather/demanddata/nrel_efs/map_states.py
@@ -2,11 +2,7 @@ from collections import defaultdict
 
 import pandas as pd
 from powersimdata.input.grid import Grid
-from powersimdata.network.usa_tamu.constants.zones import (
-    abv2state,
-    id2abv,
-    id2timezone,
-)
+from powersimdata.network.usa_tamu.constants.zones import abv2state, id2abv, id2timezone
 
 
 def decompose_demand_profile_by_state_to_loadzone(df, save=None):

--- a/prereise/gather/demanddata/nrel_efs/tests/test_aggregate_demand.py
+++ b/prereise/gather/demanddata/nrel_efs/tests/test_aggregate_demand.py
@@ -4,9 +4,7 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 from powersimdata.network.usa_tamu.constants.zones import abv2state
 
-from prereise.gather.demanddata.nrel_efs.aggregate_demand import (
-    combine_efs_demand,
-)
+from prereise.gather.demanddata.nrel_efs.aggregate_demand import combine_efs_demand
 
 
 def test_combine_efs_demand():

--- a/prereise/gather/hydrodata/eia/decompose_profile.py
+++ b/prereise/gather/hydrodata/eia/decompose_profile.py
@@ -1,9 +1,6 @@
 import pandas as pd
 from powersimdata.input.grid import Grid
-from powersimdata.network.usa_tamu.constants.zones import (
-    abv2interconnect,
-    abv2loadzone,
-)
+from powersimdata.network.usa_tamu.constants.zones import abv2interconnect, abv2loadzone
 
 
 def get_profile_by_state(profile, state):

--- a/prereise/gather/hydrodata/eia/tests/test_decompose_profile.py
+++ b/prereise/gather/hydrodata/eia/tests/test_decompose_profile.py
@@ -2,9 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from prereise.gather.hydrodata.eia.decompose_profile import (
-    get_profile_by_state,
-)
+from prereise.gather.hydrodata.eia.decompose_profile import get_profile_by_state
 
 
 def test_get_profile_argument_type():

--- a/prereise/gather/hydrodata/eia/tests/test_interpolate_capacity_factors.py
+++ b/prereise/gather/hydrodata/eia/tests/test_interpolate_capacity_factors.py
@@ -1,9 +1,7 @@
 import pandas as pd
 import pytest
 
-from prereise.gather.hydrodata.eia.interpolate_capacity_factors import (
-    get_profile,
-)
+from prereise.gather.hydrodata.eia.interpolate_capacity_factors import get_profile
 
 
 def test_get_profile_argument_type():

--- a/prereise/gather/tests/test_helpers.py
+++ b/prereise/gather/tests/test_helpers.py
@@ -2,9 +2,7 @@ import pandas as pd
 import pytest
 
 from prereise.gather.helpers import get_monthly_net_generation
-from prereise.gather.tests.mock_generation import (
-    create_mock_generation_data_frame,
-)
+from prereise.gather.tests.mock_generation import create_mock_generation_data_frame
 
 
 def test_get_monthly_net_generation_argument_type():

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ commands =
     local: pytest -m 'not integration'
     integration: pytest 
     format: black .
-    format: isort -m 3 --tc .
+    format: isort .
     checkformatting: black . --check --diff
-    checkformatting: isort -m 3 --tc --check --diff .
+    checkformatting: isort --check --diff .
+
+[isort]
+profile = black


### PR DESCRIPTION
### Purpose
We can take advantage of isort's built in "profile" for black compatibility. This includes a line length option which we were msising, along with a couple others I'm not sure about. [Source](https://github.com/PyCQA/isort/blob/develop/isort/profiles.py) from their repo is easy to read.

### What the code is doing
Added isort section in tox.ini

### Testing
Ran `tox -e format` locally, and ci passes.

### Time estimate
5 min