### PR TITLE
ci: remove obsolete token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Breakthrough-Energy/PowerSimData
-          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PowerSimData
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
### Purpose
Remove token used to clone previously private repository.

### Testing
The green check mark (pending, but assuming it passes)

### Time estimate
1 min