### PR TITLE
ci: enable PR trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: push
+on: 
+  push:
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   formatting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Pytest
 
-on: push
+on: 
+  push:
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   test:


### PR DESCRIPTION
### Purpose
Add PR trigger to support forked repositories. Turns out this is not a security concern, as actions triggered by external PRs run in a limited security context. Some details [here](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request), and [here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests).

### Testing
Will have to merge to actually test this.

### Time estimate
5 min