### PR TITLE
ci: add flake8 and fix warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,3 +15,11 @@ jobs:
       - uses: actions/setup-python@v2
       - run: python -m pip install --upgrade tox
       - run: tox -e checkformatting
+  flake8:
+    if: "!contains(github.event.head_commit.message, 'skip_ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -m pip install --upgrade tox
+      - run: tox -e flake8

--- a/prereise/gather/demanddata/nrel_efs/tests/test_aggregate_demand.py
+++ b/prereise/gather/demanddata/nrel_efs/tests/test_aggregate_demand.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 from pandas.testing import assert_frame_equal
 from powersimdata.network.usa_tamu.constants.zones import abv2state

--- a/prereise/gather/hydrodata/eia/tests/test_net_demand.py
+++ b/prereise/gather/hydrodata/eia/tests/test_net_demand.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 from powersimdata.tests.mock_scenario import MockScenario
 

--- a/prereise/gather/request_util.py
+++ b/prereise/gather/request_util.py
@@ -1,6 +1,5 @@
 import functools
 import time
-from datetime import timedelta
 from urllib.error import HTTPError
 
 

--- a/prereise/gather/solardata/ga_wind/ga_wind.py
+++ b/prereise/gather/solardata/ga_wind/ga_wind.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import dateutil
 import h5pyd
 import numpy as np

--- a/prereise/gather/solardata/nsrdb/nrel_api.py
+++ b/prereise/gather/solardata/nsrdb/nrel_api.py
@@ -5,7 +5,7 @@ from io import BytesIO
 import pandas as pd
 import requests
 
-from prereise.gather.request_util import RateLimit, TransientError, retry
+from prereise.gather.request_util import TransientError, retry
 
 
 @dataclass

--- a/prereise/gather/solardata/nsrdb/sam.py
+++ b/prereise/gather/solardata/nsrdb/sam.py
@@ -77,8 +77,6 @@ def retrieve_data(solar_plant, email, api_key, year="2016", rate_limit=0.5):
             dates=dates,
         ).to_dict()
 
-        ssc = pssc.PySSC()
-
         for i in coord[key]:
             data_site = pd.DataFrame(
                 {

--- a/prereise/gather/solardata/tests/test_pv_tracking.py
+++ b/prereise/gather/solardata/tests/test_pv_tracking.py
@@ -20,7 +20,7 @@ def test_state_exists():
 
 def test_state_without_no_solar_return_none():
     state = ["MT"]
-    assert get_pv_tracking_ratio_state(pv_info, state) == None
+    assert get_pv_tracking_ratio_state(pv_info, state) is None
 
 
 def test_state_with_solar_return_3ple():

--- a/prereise/gather/tests/test_helpers.py
+++ b/prereise/gather/tests/test_helpers.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 
 from prereise.gather.helpers import get_monthly_net_generation

--- a/prereise/gather/winddata/rap/noaa_api.py
+++ b/prereise/gather/winddata/rap/noaa_api.py
@@ -102,7 +102,7 @@ class NoaaApi:
         for time_slice in self.iter_hours(start, end):
             response = download(time_slice)
             if response.status_code == 404:
-                print(f"Got 404 response, trying fallback url.")
+                print("Got 404 response, trying fallback url.")
                 response = download(time_slice, fallback=True)
                 if response.status_code == 404:
                     print(

--- a/prereise/gather/winddata/rap/rap.py
+++ b/prereise/gather/winddata/rap/rap.py
@@ -131,7 +131,7 @@ def retrieve_data(wind_farm, start_date="2016-01-01", end_date="2016-12-31"):
                     for j in range(n_target)
                 ]
                 data_tmp["Pout"] = power
-            except Exception as e:
+            except Exception:
                 print(f"Failed to parse response from url={response.url}")
                 handle_missing(response, data_tmp)
         else:

--- a/prereise/gather/winddata/rap/tests/test_power_curves.py
+++ b/prereise/gather/winddata/rap/tests/test_power_curves.py
@@ -188,7 +188,7 @@ class TestGetForm860(unittest.TestCase):
     def test_bad_dir(self):
         bad_dir = path.abspath(path.join(path.dirname(__file__), "..", "foo"))
         with self.assertRaises(ValueError):
-            form_860 = get_form_860(bad_dir)
+            get_form_860(bad_dir)
 
     def test_default_year(self):
         form_860 = get_form_860(data_dir)
@@ -200,11 +200,11 @@ class TestGetForm860(unittest.TestCase):
 
     def test_bad_year(self):
         with self.assertRaises(ValueError):
-            form_860 = get_form_860(data_dir, year=3000)
+            get_form_860(data_dir, year=3000)
 
     def test_year_str(self):
         with self.assertRaises(TypeError):
-            form_860 = get_form_860(data_dir, year="2016")
+            get_form_860(data_dir, year="2016")
 
 
 class TestGetTurbinePowerCurves(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pytest-local, format
+envlist = pytest-local, format, flake8
 skipsdist = true
 
 [testenv]
@@ -10,6 +10,7 @@ deps =
     pytest: pipenv
     {format,checkformatting}: black
     {format,checkformatting}: isort
+    flake8: flake8
 commands =
     pytest: pipenv sync --dev
     local: pytest -m 'not integration'
@@ -18,6 +19,13 @@ commands =
     format: isort .
     checkformatting: black . --check --diff
     checkformatting: isort --check --diff .
+    flake8: flake8 prereise/
+
+[flake8]
+ignore = E501,W503,E203
+exclude = 
+    .ipynb_checkpoints
 
 [isort]
 profile = black
+


### PR DESCRIPTION
### Purpose
Add flake8 to linting workflows, as we have in other packages. Configuration in tox.ini is similar to elsewhere, but also excluding notebook files which exist locally, but outside of git. 

### What the code is doing
* Add flake8 option and configuration to tox.ini 
* Configured github action to run flake8, via tox
* Fixes to source files, mainly unused imports and variables

### Testing
tox

### Time estimate
10 min