### PR TITLE
fix: set attribute on wrapped function so it actually works

### DIFF
--- a/prereise/gather/request_util.py
+++ b/prereise/gather/request_util.py
@@ -69,16 +69,16 @@ def retry(
 
     def decorator(func):
         limiter = RateLimit(interval)
-        func.retry_count = 0
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
+            wrapper.retry_count = 0
             for i in range(max_attempts):
-                func.retry_count = i + 1
+                wrapper.retry_count = i + 1
                 try:
                     return limiter.invoke(lambda: func(*args, **kwargs))
                 except allowed_exceptions as e:
-                    if func.retry_count == max_attempts:
+                    if wrapper.retry_count == max_attempts:
                         print("Max retries reached!!")
                         if raises:
                             raise e

--- a/prereise/gather/tests/test_retry.py
+++ b/prereise/gather/tests/test_retry.py
@@ -50,3 +50,16 @@ def test_unhandled_exception():
 
     with pytest.raises(Exception):
         fail()
+
+
+def test_counter_attribute():
+    limit = 3
+
+    @retry(max_attempts=limit, allowed_exceptions=CustomException)
+    def best_attempt():
+        x = best_attempt.retry_count
+        if best_attempt.retry_count < limit:
+            raise CustomException
+        return x
+
+    assert limit == best_attempt()


### PR DESCRIPTION
### Purpose
We set an attribute on the function to retry which, initially for debugging, also enabled continuation in downloading wind data despite reaching the max attempts. However, it needs to be set on the wrapped function rather than the `func` object passed in, otherwise the decorated function won't be accessing the same value being incremented by the retry wrapper. 

### What the code is doing
Set the attribute on the right object, add a test to simulate the current usage.

### Testing
Added new unit test

### Time estimate
5 min
