### PR TITLE
Use integration marker for test fetching data

### DIFF
--- a/prereise/gather/demanddata/nrel_efs/tests/test_get_efs_data.py
+++ b/prereise/gather/demanddata/nrel_efs/tests/test_get_efs_data.py
@@ -2,6 +2,7 @@ import os
 import zipfile
 
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 from powersimdata.network.usa_tamu.constants.zones import abv2state
 
@@ -50,6 +51,7 @@ def test_check_path():
     assert test_fpath == exp_fpath
 
 
+@pytest.mark.integration
 def test_download_data():
     try:
         # Download a file using _download_data

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,4 @@
 addopts = --cov=prereise
 testpaths = prereise
 markers = 
-	integration: marks tests that requires connection to the server and
-	download data (deselect with '-m "not integration"')
+	integration: marks tests that require external dependencies (deselect with '-m "not integration"')


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Use `pytest` marker to deselect test fetching third party data

### What the code is doing
There is no code

### Testing
Test is deselected when `tox pytest-local` (equivalent to `pytest -m 'not integration'`) is invoked

### Where to look
I imported `pytest` and mark `test_download_data` as being an integration test

### Usage Example/Visuals
N/A

### Time estimate
2min
