### PR TITLE
Report code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,2 @@
 [run]
 branch = True
-omit =
-    **/test_*.py
-    **/__init__.py
-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Code coverage
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    name: Generate coverage report
+    steps:
+      - name: Checkout PreREISE
+        uses: actions/checkout@v2
+        with:
+          path: PreREISE
+
+      - name: Checkout PowerSimData
+        uses: actions/checkout@v2
+        with:
+          repository: Breakthrough-Energy/PowerSimData
+          path: PowerSimData
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - run: python -m pip install --upgrade pip tox
+        working-directory: PreREISE
+
+      - run: tox -e pytest-local -- --cov-report=xml
+        working-directory: PreREISE
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          name: codecov-prereise
+          fail_ci_if_error: true
+          directory: PreREISE

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -46,6 +46,7 @@ jobs:
           token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           commit-message: Update dependencies
           title: Update dependencies
+          labels: dependencies
           delete-branch: true
           body: |
             ### Summary of changes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
+![logo](https://raw.githubusercontent.com/Breakthrough-Energy/docs/master/source/_static/img/BE_Sciences_RGB_Horizontal_Color.svg)
+[![codecov](https://codecov.io/gh/Breakthrough-Energy/PreREISE/branch/develop/graph/badge.svg?token=4KA0ESPUA4)](https://codecov.io/gh/Breakthrough-Energy/PreREISE)
+[![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 ![Tests](https://github.com/Breakthrough-Energy/PreREISE/workflows/Pytest/badge.svg)
+[![Documentation](https://github.com/Breakthrough-Energy/docs/actions/workflows/publish.yml/badge.svg)](https://breakthrough-energy.github.io/docs/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # PreREISE
 This package gathers and builds demand, hydro, solar, and wind profiles. The profiles

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     flake8: pep8-naming
 commands =
     pytest: pipenv sync --dev
-    local: pytest -m 'not integration'
+    local: pytest -m 'not integration' {posargs}
     integration: pytest 
     format: black .
     format: isort .


### PR DESCRIPTION
### Purpose
Plumbing for reporting code coverage to codecov.io.

### What the code is doing
* Add separate github workflow, to run on merges to develop
* Parameterize `pytest-local` tox env so we can specify the xml format required by codecov
* Add dependencies label to packages.yml (unrelated, but trivial)
* Include tests in the coverage measurement
* add some missing badges

### Testing
Ran the workflow to initialize the repository on codecov and generate the badge.

### Time estimate
5 min
