### PR TITLE
feat: add stubs for demand and hydro data cli

### DIFF
--- a/prereise/cli/data_sources/__init__.py
+++ b/prereise/cli/data_sources/__init__.py
@@ -1,3 +1,5 @@
+from prereise.cli.data_sources.demand_data import DemandData
+from prereise.cli.data_sources.hydro_data import HydroData
 from prereise.cli.data_sources.solar_data import (
     SolarDataGriddedAtmospheric,
     SolarDataNationalSolarRadiationDatabase,
@@ -14,4 +16,6 @@ def get_data_sources_list():
         WindDataRapidRefresh(),
         SolarDataGriddedAtmospheric(),
         SolarDataNationalSolarRadiationDatabase(),
+        DemandData(),
+        HydroData(),
     ]

--- a/prereise/cli/data_sources/data_source.py
+++ b/prereise/cli/data_sources/data_source.py
@@ -1,5 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
+from prereise.cli.data_sources.exceptions import CommandNotSupportedError
+
 
 class DataSource(metaclass=ABCMeta):
     """Abstract class that defines a strict interface
@@ -45,3 +47,25 @@ class DataSource(metaclass=ABCMeta):
         the appropriate data and saves it somewhere.
         """
         pass
+
+
+class NotSupportedDataSource(DataSource):
+    @property
+    def command_help(self):
+        """See :py:func:`prereise.cli.data_sources.data_source.DataSource.command_help`
+
+        :return: (*str*) -- help messsage
+        """
+        return "Currently unsupported, please see documentation to see how to download"
+
+    @property
+    def extract_arguments(self):
+        """See :py:func:`prereise.cli.data_sources.data_source.DataSource.extract_arguments`
+
+        :return: (*list*) -- list of arguments to pass into argparse
+        """
+        return []
+
+    def extract(self, **kwargs):
+        """See :py:func:`prereise.cli.data_sources.data_source.DataSource.extract`"""
+        raise CommandNotSupportedError()

--- a/prereise/cli/data_sources/demand_data.py
+++ b/prereise/cli/data_sources/demand_data.py
@@ -1,0 +1,11 @@
+from prereise.cli.data_sources.data_source import NotSupportedDataSource
+
+
+class DemandData(NotSupportedDataSource):
+    @property
+    def command_name(self):
+        """See :py:func:`prereise.cli.data_sources.data_source.DataSource.command_name`
+
+        :return: (*str*) -- command name
+        """
+        return "demand_data"

--- a/prereise/cli/data_sources/exceptions.py
+++ b/prereise/cli/data_sources/exceptions.py
@@ -1,0 +1,2 @@
+class CommandNotSupportedError(Exception):
+    pass

--- a/prereise/cli/data_sources/hydro_data.py
+++ b/prereise/cli/data_sources/hydro_data.py
@@ -1,0 +1,11 @@
+from prereise.cli.data_sources.data_source import NotSupportedDataSource
+
+
+class HydroData(NotSupportedDataSource):
+    @property
+    def command_name(self):
+        """See :py:func:`prereise.cli.data_sources.data_source.DataSource.command_name`
+
+        :return: (*str*) -- command name
+        """
+        return "hydro_data"

--- a/prereise/cli/data_sources/tests/test_demand_data.py
+++ b/prereise/cli/data_sources/tests/test_demand_data.py
@@ -1,0 +1,9 @@
+import pytest
+
+from prereise.cli.data_sources.demand_data import DemandData
+from prereise.cli.data_sources.exceptions import CommandNotSupportedError
+
+
+def test_demand_data_happy_path():
+    with pytest.raises(CommandNotSupportedError):
+        DemandData().extract()

--- a/prereise/cli/data_sources/tests/test_hydro_data.py
+++ b/prereise/cli/data_sources/tests/test_hydro_data.py
@@ -1,0 +1,9 @@
+import pytest
+
+from prereise.cli.data_sources.exceptions import CommandNotSupportedError
+from prereise.cli.data_sources.hydro_data import HydroData
+
+
+def test_hydro_data_happy_path():
+    with pytest.raises(CommandNotSupportedError):
+        HydroData().extract()


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
What is the larger goal of this change?
This is the last planned part of the [download manager project](https://breakthrough-energy.github.io/docs/communication/project_ideas.html#project-1a-download-manager). As per discussion with @rouille and @BainanXia, demand data and hydro data is very complex and a very manual process to generate. In addition, most of the data is already downloaded and available locally, so there's no data to download. This PR adds two stub classes for demand and hydro data for completion sake

### What the code is doing
How is the purpose executed?
Two stub classes for hydro and demand data are created that simply raise exceptions. Classes can be filled in in the future if process of gathering data is simplified/if people find themselves repeatedly downloading the data enough such that it warrants automation. 

### Testing
How did you test this change (unit/functional testing, manual testing, etc.)? 
unit tests and manually running cli

### Where to look
Most new code is under prereise/cli

### Time estimate
How long will it take for reviewers and observers to understand this code change?
15 minutes
