### PR TITLE
feat: add functions to perform transmission line filtering

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -52,3 +52,8 @@ abv2state = {
     "WV": "West Virginia",
     "WY": "Wyoming",
 }
+
+blob_paths = {
+    "substations": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Substations_Jul2020.csv",
+    "transmission_lines": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Power_Transmission_Lines_Jul2020.geojson.zip",
+}

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -1,0 +1,41 @@
+import os
+
+from powersimdata.utility.distance import haversine
+
+from prereise.gather.griddata.hifld import const
+from prereise.gather.griddata.hifld.data_access.load import (
+    get_hifld_electric_power_transmission_lines,
+    get_hifld_electric_substations,
+    get_zone,
+)
+
+
+def filter_substations_with_zero_lines(substations):
+    """Filter substations with LINES attribute equal to zero, and report the number
+    dropped.
+
+    :param pandas.DataFrame substations: data frame of all substations.
+    :return: (*pandas.DataFrame*) -- substations with non-zero values for LINES.
+    """
+    num_substations = len(substations)
+    num_substations_without_lines = len(substations.query("LINES == 0"))
+    print(
+        f"dropping {num_substations_without_lines} substations "
+        f"of {num_substations} total due to LINES parameter equal to 0"
+    )
+
+    return substations.query("LINES != 0").copy()
+
+
+def build_transmission():
+    """Main user-facing entry point."""
+    # Load input data
+    hifld_substations = get_hifld_electric_substations(const.blob_paths["substations"])
+    hifld_lines = get_hifld_electric_power_transmission_lines(
+        const.blob_paths["transmission_lines"]
+    )
+    hifld_data_dir = os.path.join(os.path.dirname(__file__), "..", "data")
+    hifld_zones = get_zone(os.path.join(hifld_data_dir, "zone.csv"))  # noqa: F841
+
+    # Filter substations
+    substations_with_lines = filter_substations_with_zero_lines(hifld_substations)

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -58,6 +58,27 @@ def filter_lines_with_unavailable_substations(lines):
     return lines.query("SUB_1 != 'NOT AVAILABLE' and SUB_2 != 'NOT AVAILABLE'").copy()
 
 
+def filter_lines_with_no_matching_substations(lines, substations):
+    """Filter lines with one or more substation name not present in the ``substations``
+    data frame, and report the number dropped.
+
+    :param pandas.DataFrame lines: data frame of lines.
+    :param pandas.DataFrame substations: data frame of substations.
+    :return: (*pandas.DataFrame*) -- lines with matching substations.
+    """
+    num_lines = len(lines)
+    matching_names = substations["NAME"]  # noqa: F841
+    filtered = lines.query(
+        "SUB_1 not in @matching_names or SUB_2 not in @matching_names"
+    )
+    num_filtered = len(filtered)
+    print(
+        f"dropping {num_filtered} lines with one or more substations not found in "
+        f"substations table out of a starting total of {num_lines}"
+    )
+    return lines.query("SUB_1 in @matching_names and SUB_2 in @matching_names").copy()
+
+
 def build_transmission():
     """Main user-facing entry point."""
     # Load input data
@@ -74,3 +95,6 @@ def build_transmission():
 
     # Filter lines
     lines_with_substations = filter_lines_with_unavailable_substations(hifld_lines)
+    lines_with_matching_substations = filter_lines_with_no_matching_substations(
+        lines_with_substations, substations_with_lines
+    )

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -41,6 +41,23 @@ def filter_substations_with_zero_lines(substations):
     return substations.query("LINES != 0").copy()
 
 
+def filter_lines_with_unavailable_substations(lines):
+    """Filter lines with SUB_1 or SUB_2 attribute equal to 'NOT AVAILABLE', and report
+    the number dropped.
+
+    :param pandas.DataFrame lines: data frame of all lines.
+    :return: (*pandas.DataFrame*) -- lines with available substations.
+    """
+    num_lines = len(lines)
+    filtered = lines.query("SUB_1 == 'NOT AVAILABLE' or SUB_2 == 'NOT AVAILABLE'")
+    num_filtered = len(filtered)
+    print(
+        f"dropping {num_filtered} lines with one or more substations listed as "
+        f"'NOT AVAILABLE' out of a starting total of {num_lines}"
+    )
+    return lines.query("SUB_1 != 'NOT AVAILABLE' and SUB_2 != 'NOT AVAILABLE'").copy()
+
+
 def build_transmission():
     """Main user-facing entry point."""
     # Load input data
@@ -54,3 +71,6 @@ def build_transmission():
     # Filter substations
     substations_with_lines = filter_substations_with_zero_lines(hifld_substations)
     check_for_location_conflicts(substations_with_lines)
+
+    # Filter lines
+    lines_with_substations = filter_lines_with_unavailable_substations(hifld_lines)

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -10,6 +10,20 @@ from prereise.gather.griddata.hifld.data_access.load import (
 )
 
 
+def check_for_location_conflicts(substations):
+    """Check for multiple substations with identical lat/lon.
+
+    :param pandas.DataFrame substations: data frame of substations.
+    :raises ValueError: if multiple substations with identical lat/lon.
+    """
+    num_substations = len(substations)
+    num_lat_lon_groups = len(substations.groupby(["LATITUDE", "LONGITUDE"]))
+    if num_lat_lon_groups != num_substations:
+        num_collisions = num_substations - num_lat_lon_groups
+        raise ValueError(
+            f"There are {num_collisions} substations with duplicate lat/lon values"
+        )
+
 def filter_substations_with_zero_lines(substations):
     """Filter substations with LINES attribute equal to zero, and report the number
     dropped.
@@ -39,3 +53,4 @@ def build_transmission():
 
     # Filter substations
     substations_with_lines = filter_substations_with_zero_lines(hifld_substations)
+    check_for_location_conflicts(substations_with_lines)

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -128,6 +128,23 @@ def filter_lines_with_nonmatching_substation_coords(lines, substations, threshol
     return remaining.copy()
 
 
+def filter_lines_with_identical_substation_names(lines):
+    """Filter lines with SUB_1 or SUB_2 attributes equal to each other, and report the
+    number dropped.
+
+    :param pandas.DataFrame lines: data frame of lines.
+    :return: (*pandas.DataFrame*) -- lines with distinct substations.
+    """
+    num_lines = len(lines)
+    filtered = lines.query("SUB_1 == SUB_2")
+    num_filtered = len(filtered)
+    print(
+        f"dropping {num_filtered} lines with matching SUB_1 and SUB_2 out of a "
+        f"starting total of {num_lines}"
+    )
+    return lines.query("SUB_1 != SUB_2").copy()
+
+
 def build_transmission():
     """Main user-facing entry point."""
     # Load input data
@@ -150,3 +167,7 @@ def build_transmission():
     lines_with_matching_substations = filter_lines_with_nonmatching_substation_coords(
         lines_with_matching_substations, substations_with_lines
     )
+    lines_with_matching_substations = filter_lines_with_identical_substation_names(
+        lines_with_matching_substations
+    )
+    return lines_with_matching_substations


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Implement initial filtering of transmission lines and substations, following the lead from @LFPower, @terrywqf, and @Mingze-Li128.

### What the code is doing
- `build_transmission` is the main user-facing function, which kicks off several lower-level functions in turn. This will eventually produce the final transmission network topology (substations, buses, branches), although this PR does not go that far.
- `get_substations_with_nonzero_lines` filters based on the `LINES` column of the substation table (as done in the `clean` function of @Mingze-Li128's branch).
- `check_for_location_conflicts` checks for any substations with duplicate lat/lon pairs.
- `filter_lines_with_unavailable_substations` looks for lines for which one or more substation is listed as `"NOT AVAILABLE"` in the line table (as done in the `neighbors` function of @Mingze-Li128's branch).
- `filter_lines_with_no_matching_substations` looks for lines for which there is no matching substation in the substation table (as done in the `neighbors` function of @Mingze-Li128's branch).
- `filter_lines_with_nonmatching_substation_coords` checks that the line start coordinates are within 100 miles of the coordinates of the substation listed in the `SUB_1` column, and that the line end coordinates are within 100 miles of the coordinates of the substations listed in the `SUB_2` column (as done in the `neighbors` function of @Mingze-Li128's branch).
- `filter_lines_with_identical_substation_names` does what the name suggests (as done in the `neighbors` function of @Mingze-Li128's branch).

### Testing
Manually tested, by replacing `BLOB_PATH` and `REPO_PATH` placeholders with locally-appropriate locations.

### Usage Example/Visuals
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
dropping 759 lines with one or more substations listed as 'NOT AVAILABLE' out of a starting total of 71554
dropping 3143 lines with one or more substations not found in substations table out of a starting total of 70795
Evaluating endpoint location mismatches... (this may take several minutes)
dropping 120 lines with one or more substations with non-matching coordinates out of a starting total of 67652
dropping 143 lines with matching SUB_1 and SUB_2 out of a starting total of 67532

[...big ugly dataframe output truncated manually by Daniel]

[67389 rows x 16 columns]
```

### Time estimate
30 minutes.
