### PR TITLE
refactor: use groupby to speed up distance calculations

### DIFF
--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -93,24 +93,25 @@ def filter_lines_with_nonmatching_substation_coords(lines, substations, threshol
     :return: (*pandas.DataFrame*) -- lines with matching substations.
     """
 
-    def find_closest_substation_and_distance(coordinates, name, substations):
-        matching_substations = substations.loc[substations.NAME == name]
+    def find_closest_substation_and_distance(coordinates, name, substations_groupby):
+        matching_substations = substations_groupby.get_group(name)
         distances = matching_substations.apply(
             lambda x: haversine(coordinates, (x.LATITUDE, x.LONGITUDE)), axis=1
         )
         return pd.Series([distances.idxmin(), distances.min()], index=["sub", "dist"])
 
     print("Evaluating endpoint location mismatches... (this may take several minutes)")
+    substations_groupby = substations.groupby("NAME")
     # Coordinates are initially (lon, lat); we reverse to (lat, lon) for haversine
     start_subs = lines.apply(
         lambda x: find_closest_substation_and_distance(
-            x.loc["COORDINATES"][0][::-1], x.loc["SUB_1"], substations
+            x.loc["COORDINATES"][0][::-1], x.loc["SUB_1"], substations_groupby
         ),
         axis=1,
     )
     end_subs = lines.apply(
         lambda x: find_closest_substation_and_distance(
-            x.loc["COORDINATES"][-1][::-1], x.loc["SUB_2"], substations
+            x.loc["COORDINATES"][-1][::-1], x.loc["SUB_2"], substations_groupby
         ),
         axis=1,
     )


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Speed up the substation matching/distance function introduced in #199 and modified in #202. No change in logic, just in implementation.

### What the code is doing
Within `filter_lines_with_nonmatching_substation_coords` we call `find_closest_substation_and_distance` N times, where `N` is the number of lines.

- Before: In each call to `find_closest_substation_and_distance` we filter the entire substations dataframe to find substations with a given name.
- After: within `filter_lines_with_nonmatching_substation_coords` we group the substations by name once, and then within `find_closest_substation_and_distance` we just call `get_group` on the already-grouped-by-name substations `GroupBy` object.

I would expect that filtering a dataframe is O(n) (`n` is the number of rows) but that getting a group is probably O(1) (if it's dict-like), which explains the dramatic speed-up.

### Testing
Tested manually. Before, `filter_lines_with_nonmatching_substation_coords` took approximately 10 minutes, now it takes approximately 2 minutes. The inefficient filtering was giving us >=400% overhead on the distance calculations themselves.

### Usage Example/Visuals
```python
from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
lines = build_transmission()
```

### Time estimate
5-10 minutes.
