### PR TITLE
feat: add function to infer line voltages

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -57,3 +57,10 @@ blob_paths = {
     "substations": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Substations_Jul2020.csv",
     "transmission_lines": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Power_Transmission_Lines_Jul2020.geojson.zip",
 }
+
+volt_class_defaults = {
+    "UNDER 100": 69,
+    "220-287": 230,
+    "345": 345,
+    "500": 500,
+}

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -96,6 +96,9 @@ def get_hifld_electric_power_transmission_lines(path):
         line["geometry"]["coordinates"][0] for line in data["features"]
     ]
 
+    # Replace dummy data with explicit 'missing'
+    properties.loc[properties.VOLTAGE == -999999, "VOLTAGE"] = pd.NA
+
     return properties.query("STATUS == 'IN SERVICE'")
 
 

--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_series_equal
+
+from prereise.gather.griddata.hifld.data_process.transmission import (
+    augment_line_voltages,
+)
+
+
+def test_augment_line_voltages_volt_class():
+    substations = pd.DataFrame({"STATE": ["CA", "OR", "NV", "WA"]})
+    lines_orig = pd.DataFrame(
+        {
+            "SUB_1_ID": list(range(4)),
+            "SUB_2_ID": list(range(1, 4)) + [0],
+            "VOLTAGE": [None] * 4,
+            "VOLT_CLASS": ["UNDER 100", "220-287", "345", "500"],
+        }
+    )
+    expected_return = pd.Series([69, 230, 345, 500], name="VOLTAGE", dtype=float)
+    lines_to_augment = lines_orig.copy()
+    with pytest.raises(AssertionError):
+        assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+    augment_line_voltages(lines_to_augment, substations)
+    assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+
+
+def test_augment_lines_voltages_state_class():
+    substations = pd.DataFrame({"STATE": ["WA"] * 100})
+    lines_orig = pd.DataFrame(
+        {
+            "SUB_1_ID": list(range(100)),
+            "SUB_2_ID": list(range(1, 100)) + [0],
+            "VOLTAGE": [115] * 97 + [138, None, 161],
+            "VOLT_CLASS": ["100-161"] * 100,
+        }
+    )
+    expected_return = pd.Series(
+        [115] * 97 + [138, 115, 161], name="VOLTAGE", dtype=float
+    )
+    lines_to_augment = lines_orig.copy()
+    with pytest.raises(AssertionError):
+        assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+    augment_line_voltages(lines_to_augment, substations)
+    assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+
+
+def test_augment_lines_voltages_neighbor_consensus():
+    substations = pd.DataFrame({"STATE": ["CA", "OR", "NV", "WA"]})
+    lines_orig = pd.DataFrame(
+        {
+            "SUB_1_ID": list(range(4)),
+            "SUB_2_ID": list(range(1, 4)) + [0],
+            "VOLTAGE": [138, 230, None, 230],
+            "VOLT_CLASS": ["FOO"] * 4,
+        }
+    )
+    expected_return = pd.Series([138, 230, 230, 230], name="VOLTAGE", dtype=float)
+    lines_to_augment = lines_orig.copy()
+    with pytest.raises(AssertionError):
+        assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+    augment_line_voltages(lines_to_augment, substations)
+    assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+
+
+def test_augment_lines_voltages_neighbor_minimum():
+    substations = pd.DataFrame({"STATE": ["CA", "OR", "NV", "WA"]})
+    lines_orig = pd.DataFrame(
+        {
+            "SUB_1_ID": list(range(4)),
+            "SUB_2_ID": list(range(1, 4)) + [0],
+            "VOLTAGE": [138, 230, None, 231],
+            "VOLT_CLASS": ["FOO"] * 4,
+        }
+    )
+    expected_return = pd.Series([138, 230, 230, 231], name="VOLTAGE", dtype=float)
+    lines_to_augment = lines_orig.copy()
+    with pytest.raises(AssertionError):
+        assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+    augment_line_voltages(lines_to_augment, substations)
+    assert_series_equal(lines_to_augment.VOLTAGE, expected_return)

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -279,6 +279,9 @@ def augment_line_voltages(
         lines, neighbors, lambda x: min(x) if len(x) > 0 else None, "minimum"
     )
 
+    # Ensure that voltages are floats
+    lines["VOLTAGE"] = lines["VOLTAGE"].astype(float)
+
 
 def build_transmission():
     """Main user-facing entry point."""

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -179,15 +179,23 @@ def filter_by_connected_components(lines, substations):
     return remaining_lines, remaining_substations
 
 
-def augment_line_voltages(lines, substations):
+def augment_line_voltages(lines, substations, volt_class_defaults=None):
     """Fill in voltages for lines with missing voltages, using a series of heuristics.
     The ``lines`` dataframe will be modified in-place.
 
     :param pandas.DataFrame lines: data frame of lines.
     :param pandas.DataFrame substations: data frame of substations.
+    :param dict/pandas.Series volt_class_defaults: mapping of volt classes to default
+        replacement voltage values. If None, internally-defined defaults will be used.
     """
-    pass
+    # Interpret input parameters
+    if volt_class_defaults is None:
+        volt_class_defaults = const.volt_class_defaults
 
+    # Set voltages based on voltage class defaults
+    null_voltages = lines.loc[lines.VOLTAGE.isna()]
+    replacement_voltages = null_voltages.VOLT_CLASS.map(volt_class_defaults)
+    lines.loc[lines.VOLTAGE.isna(), "VOLTAGE"] = replacement_voltages
 
 def build_transmission():
     """Main user-facing entry point."""

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -179,6 +179,16 @@ def filter_by_connected_components(lines, substations):
     return remaining_lines, remaining_substations
 
 
+def augment_line_voltages(lines, substations):
+    """Fill in voltages for lines with missing voltages, using a series of heuristics.
+    The ``lines`` dataframe will be modified in-place.
+
+    :param pandas.DataFrame lines: data frame of lines.
+    :param pandas.DataFrame substations: data frame of substations.
+    """
+    pass
+
+
 def build_transmission():
     """Main user-facing entry point."""
     # Load input data
@@ -200,5 +210,8 @@ def build_transmission():
     lines = filter_lines_with_no_matching_substations(lines, substations)
     lines = filter_lines_with_nonmatching_substation_coords(lines, substations)
     lines = filter_lines_with_identical_substation_names(lines)
+
+    # Add voltages to lines with missing data
+    augment_line_voltages(lines, substations)
 
     return lines, substations

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -187,6 +187,7 @@ def build_transmission():
     hifld_lines = get_hifld_electric_power_transmission_lines(
         const.blob_paths["transmission_lines"]
     )
+    hifld_lines.set_index("ID", inplace=True)
     hifld_data_dir = os.path.join(os.path.dirname(__file__), "..", "data")
     hifld_zones = get_zone(os.path.join(hifld_data_dir, "zone.csv"))  # noqa: F841
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Within the raw HIFLD data, there are many transmission lines with unknown voltages. Per #205, we need to determine a voltage for each transmission line in order to be able to create buses within substations. This is an attempt to create a process that fulfills this requirement, and currently achieves 100% coverage on the largest connected component.

### What the code is doing

~We create a new helper function `safe_get_group`, which can be used to call `get_group` on a pandas `GroupBy` object and has a default behavior if the key is not present. This is used within the new `augment_line_voltages` function to improve computational performance.~ EDIT: this function is no longer necessary and has been removed.

All new voltage-assigning logic goes into the `augment_line_voltages` function. There are four stages of inference, applied sequentially to lines which still have no `VOLTAGE` attribute:
1. We apply a dictionary to assign voltages to un-labelled lines according to their `VOLT_CLASS` attribute (there is a default value for this dict, or the user can specify). This is a good approach for all classes besides 100-161 kV (see details in #205).
2. ~For the 100-161 kV class, we identify states for which >= 95% of labelled lines in this class are of a single voltage level. This results in:~
  - ~115 kV for CT, GA, MA, ME, ND, NH, NM, NY, OR, RI, SD, VT, WA, and WY.~
  - ~138 kV for DE, ID, IL, IN, OH, and WV.~
  - ~161 kV for TN.~
  - ~No clear voltage class for: AL, AR, AZ, CA, CO, FL, IA, KS, KY, LA, MD, MI, MN, MO, MS, MT, NC, NE, NJ, NV, OK, PA, SC, TX, UT, VA, or WI.~
2. For the 100-161 kV class, we identify (from state, to state) combinations for which >= 95% of labelled lines in this class are of a single voltage level. This is an update from the original method, in which each line was classified as part of a single state based on an arbitrarily chosen endpoint. Discussion of differences can be found in [this comment thread](https://github.com/Breakthrough-Energy/PreREISE/pull/208#discussion_r699609276). This 95% threshold is a default value, but another value can be supplied by the user instead.
3. We identify a set of voltages of neighboring lines, and if these voltages are all the same then we apply this voltage to the line. This is done iteratively until no more progress is made (i.e. all remaining lines have either no neighboring voltages, or multiple distinct neighboring voltages).
4. We identify a set of voltages of neighboring lines, and assign the lowest of these voltages to the line. This is done iteratively until no more progress is made (i.e. all remaining lines have no neighboring voltages).

At the start of this process, there are 11,856 lines with missing voltage data (mostly `NOT AVAILABLE`, `UNDER 100`, or `100-161` voltage classes). After step 1, there are 8,375 missing voltages remaining (all `NOT AVAILABLE` or `100-161` voltage class). After step 2, there are ~7,708~ 7,696 (values have been updated based on the two-state step 2 method, as noted above) missing voltages remaining (the number of `100-161` voltage class lines has been reduced but not eliminated). After step 3, there are ~2,118~ 2,119 missing voltage remaining (after 15 iterations of this heuristic). After step 4, there are 310 missing voltage remaining (after 7 iterations of this heuristic). None of these lines are part of the largest connected component (as demonstrated below), or they would have been addressed by step 4.

### Testing
Tests are added which illustrate each step being tested.

### Usage Example
Manual usage demonstrates the outputs to the user, and that no un-labelled lines remain within the largest connected component.
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> lines, substations = build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
dropping 759 lines with one or more substations listed as 'NOT AVAILABLE' out of a starting total of 71554
dropping 3143 lines with one or more substations not found in substations table out of a starting total of 70795
Evaluating endpoint location mismatches... (this may take several minutes)
dropping 120 lines with one or more substations with non-matching coordinates out of a starting total of 67652
dropping 143 lines with matching SUB_1 and SUB_2 out of a starting total of 67532
2118 line voltages can't be found via neighbor consensus
310 line voltages can't be found via lowest_neighbor
>>> import networkx as nx
>>> graph = nx.convert_matrix.from_pandas_edgelist(lines, "SUB_1_ID", "SUB_2_ID")
>>> sorted_cc = sorted(nx.connected_components(graph), key=len)[::-1]
>>> largest_island = sorted_cc[0]
>>> lines.query("VOLTAGE.isnull() and SUB_1_ID in @largest_island")
Empty DataFrame
Columns: [ID, TYPE, STATUS, NAICS_CODE, NAICS_DESC, SOURCE, SOURCEDATE, VAL_METHOD, VAL_DATE, OWNER, VOLTAGE, VOLT_CLASS, INFERRED, SUB_1, SUB_2, COORDINATES, SUB_1_ID, SUB_2_ID]
Index: []
```

### Time estimate
15-30 minutes to understand the current logic, more if you want to brainstorm alternative approaches. I'm by no means saying this is the _best_ approach, just one that gets us towards #205, after which we can start on #206 and finish #197. Once we have #206 implemented, we can test alternative approaches to this process, e.g. to try to improve the number of transformers required.