### PR TITLE
feat: add function to create buses from substations and lines

### DIFF
--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from prereise.gather.griddata.hifld.data_process.transmission import (
     augment_line_voltages,
+    create_buses,
 )
 
 
@@ -79,3 +80,23 @@ def test_augment_lines_voltages_neighbor_minimum():
         assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
     augment_line_voltages(lines_to_augment, substations)
     assert_series_equal(lines_to_augment.VOLTAGE, expected_return)
+
+
+def test_create_buses():
+    lines = pd.DataFrame(
+        {
+            "SUB_1_ID": [1, 2, 3, 3],
+            "SUB_2_ID": [2, 3, 4, 1],
+            "VOLTAGE": [69, 115, 230, 345],
+        }
+    )
+
+    expected_return = pd.DataFrame(
+        {
+            "sub_id": [1, 1, 2, 2, 3, 3, 3, 4],
+            "baseKV": [69, 345, 69, 115, 115, 230, 345, 230],
+        },
+    )
+    expected_return["baseKV"] = expected_return["baseKV"].astype(float)
+    bus = create_buses(lines)
+    assert_frame_equal(bus, expected_return)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Address #205 by starting the bus data frame. ~This PR depends on #208, which is why it is currently listed as the PR target (so that only the changes since then are shown), but this PR will eventually target the `hifld` branch.~ EDIT: #208 has been merged, so this targets `hifld` now.

### What the code is doing
- The `lines` and `substations` data frames are used to identify the set of voltages attaches to each substation.
- This set is exploded to yield a Series entry for (substation, voltage) combination.
- The index is set to be a column, then this column is popped out to the data frame to become the `bus2sub` mapping.

### Testing
A unit test has been added to demonstrate/verify the functionality on a simple test case.

### Usage Example
We can see that `bus` and `bus2sub` are created as intended, and that there are more unique buses than unique substations (i.e. multiple buses are created within substations)
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> from prereise.gather.griddata.hifld.data_process.transmission import create_buses
>>> lines, substations = build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
dropping 759 lines with one or more substations listed as 'NOT AVAILABLE' out of a starting total of 71554
dropping 3143 lines with one or more substations not found in substations table out of a starting total of 70795
Evaluating endpoint location mismatches... (this may take several minutes)
dropping 120 lines with one or more substations with non-matching coordinates out of a starting total of 67652
dropping 143 lines with matching SUB_1 and SUB_2 out of a starting total of 67532
2119 line voltages can't be found via neighbor consensus
310 line voltages can't be found via neighbor minimum
>>> bus, bus2sub = create_buses(lines)
>>> bus
0         69.0
1        161.0
2         69.0
3        115.0
4        115.0
         ...
58279    138.0
58280    138.0
58281    345.0
58282    138.0
58283    345.0
Name: baseKV, Length: 58284, dtype: float64
>>> bus2sub
0        107655.0
1        107655.0
2        107656.0
3        107656.0
4        107657.0
           ...
58279    310905.0
58280    310906.0
58281    310907.0
58282    310908.0
58283    310924.0
Name: sub_id, Length: 58284, dtype: float64
>>> len(substations)
63965
>>> len(bus2sub.unique())
52885
>>> bus.value_counts(dropna=False)
69.0     19852
115.0    14529
138.0     9842
230.0     4322
161.0     3859
345.0     1533
100.0     1400
60.0       806
500.0      510
66.0       460
120.0      332
46.0       255
34.5       225
70.0       109
92.0        74
33.0        56
765.0       37
41.6        30
34.0        22
55.0         9
220.0        5
110.0        5
13.8         2
250.0        2
287.0        2
450.0        2
88.0         2
200.0        2
Name: baseKV, dtype: int64
```

### Time estimate
15 minutes.
