### PR TITLE
feat: add function to create transformers within substations

### DIFF
--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -5,6 +5,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from prereise.gather.griddata.hifld.data_process.transmission import (
     augment_line_voltages,
     create_buses,
+    create_transformers,
 )
 
 
@@ -100,3 +101,18 @@ def test_create_buses():
     expected_return["baseKV"] = expected_return["baseKV"].astype(float)
     bus = create_buses(lines)
     assert_frame_equal(bus, expected_return)
+
+
+def test_create_transformers():
+    bus = pd.DataFrame(
+        {
+            "sub_id": [1, 1, 2, 2, 3, 3, 3, 4],
+            "baseKV": [69, 345, 69, 115, 115, 230, 345, 230],
+        },
+        dtype="float",
+    )
+    expected_transformers = pd.DataFrame(
+        {"from_bus_id": [0, 2, 4, 5], "to_bus_id": [1, 3, 6, 6]}
+    )
+    transformers = create_transformers(bus)
+    assert_frame_equal(transformers, expected_transformers)

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -303,6 +303,25 @@ def create_buses(lines):
     return buses
 
 
+def create_transformers(bus):
+    """Add transformers between buses within the same substation. The assumed topology
+    is that the highest-voltage bus in each substation is connected via a tansformer to
+    every other voltage.
+
+    :param pandas.DataFrame bus: columns 'sub_id' and 'baseKV'
+    :return: (*pandas.DataFrame*) -- each row is one transformer, columns are
+        ["from_bus_id", "to_bus_id"].
+    """
+    bus_pairs = [
+        (b, volt_series.idxmax())
+        for sub, volt_series in bus.groupby("sub_id")["baseKV"]
+        for b in volt_series.sort_values().index[:-1]
+        if len(volt_series) > 1
+    ]
+
+    return pd.DataFrame(bus_pairs, columns=["from_bus_id", "to_bus_id"])
+
+
 def build_transmission():
     """Main user-facing entry point."""
     # Load input data


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Closes #206. ~This is a draft PR right now, since it relies on code from #210. It could also become part of #210.~

### What the code is doing
Using buses, grouped by substation, for each substation with more than one bus, a transformer is added between the highest-voltage bus in the substation and each other bus. This is an arbitrary topology that seems reasonable enough, although it is by no means the best one.

### Testing
A new unit test is added which covers the bases of: no transformers within a substation, one transformer within a substation, multiple transformers within a substation.

### Usage Example
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import (
...     build_transmission,
...     create_buses,
...     create_transformers,
... )
>>> lines, substations = build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
dropping 759 lines with one or more substations listed as 'NOT AVAILABLE' out of a starting total of 71554
dropping 3143 lines with one or more substations not found in substations table out of a starting total of 70795
Evaluating endpoint location mismatches... (this may take several minutes)
dropping 120 lines with one or more substations with non-matching coordinates out of a starting total of 67652
dropping 143 lines with matching SUB_1 and SUB_2 out of a starting total of 67532
2119 line voltages can't be found via neighbor consensus
310 line voltages can't be found via neighbor minimum
>>> bus, bus2sub = create_buses(lines)
>>> transformers = create_transformers(bus, bus2sub)
>>> transformers
      from_bus_id  to_bus_id
0               0          1
1               2          3
2               5          6
3              12         13
4              20         21
...           ...        ...
5394        58235      58236
5395        58239      58240
5396        58246      58247
5397        58258      58259
5398        58262      58263

[5399 rows x 2 columns]
```

### Time estimate
15 minutes.
