### PR TITLE
refactor: switch (lon, lat) points to (lat, lon)

### DIFF
--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -154,6 +154,10 @@ def get_hifld_electric_power_transmission_lines(path):
     properties["COORDINATES"] = [
         line["geometry"]["coordinates"][0] for line in data["features"]
     ]
+    # Flip [(lon, lat), (lon, lat), ..] points to [(lat, lon), (lat, lon), ...]
+    properties["COORDINATES"] = properties["COORDINATES"].map(
+        lambda x: [y[::-1] for y in x]
+    )
 
     # Replace dummy data with explicit 'missing'
     properties.loc[properties.VOLTAGE == -999999, "VOLTAGE"] = pd.NA


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Switch [(lon, lat), (lon, lat), ..] points to [(lat, lon), (lat, lon), ...] when we load coordinates, to match our convention in the rest of the codebase. See conversation at https://github.com/Breakthrough-Energy/PreREISE/pull/219#discussion_r707615437

### What the code is doing
It's a fancy one-liner, applied to each coordinates list in the data frame. The inner-most `list`/`zip` pair collects the `[(lon, lat), (lon, lat), ..]` points as `[(lon, lon, ...), (lat, lat, ...)]`, then this 2-length list is reversed, and the outer-most `list`/`zip` re-expands to `[(lat, lon), (lat, lon), ...]`. A simple example:
```python
>>> a = [(1, 2), (3, 4), (5, 6)]
>>> list(zip(*list(zip(*a))[::-1]))
[(2, 1), (4, 3), (6, 5)]
```

### Testing
Tested manually. Before:
```python
>>> from prereise.gather.griddata.hifld import const
>>> from prereise.gather.griddata.hifld.data_access import load
>>> lines = load.get_hifld_electric_power_transmission_lines(const.blob_paths["transmission_lines"])
>>> lines.iloc[0]["COORDINATES"]
[[-122.11300327699996, 48.18834609800007], [-122.11224433699999, 48.18844025300007], [-122.11179104899998, 48.18846523700006], [-122.11164471199999, 48.188868556000045], [-122.10942467499996, 48.18946104200006], [-122.10576625399995, 48.19038189300005], [-122.10404590399997, 48.19083161100008], [-122.10268604199996, 48.19118139200003], [-122.09992348699996, 48.191877384000065], [-122.09708954899997, 48.19261620700007], [-122.09405573699996, 48.19340856700006], [-122.09192135999996, 48.19400105300008], [-122.08790602, 48.19522885500004], [-122.08597151799995, 48.195828479000056], [-122.08413005299997, 48.196375755000076], [-122.08322585799999, 48.19659466600007], [-122.07983274599997, 48.19769635600005], [-122.07226130099997, 48.20000443300006], [-122.07046242899997, 48.201360726000075], [-122.06871590499998, 48.20268846500005], [-122.06671239799999, 48.20419228500003], [-122.06214859199997, 48.204125660000045], [-122.05664727799996, 48.20403524000005], [-122.05160757999994, 48.206528915000035], [-122.046039641, 48.20927957200007], [-122.04373632299996, 48.210388401000046], [-122.04032417599996, 48.21212064900004], [-122.03485617399997, 48.21338176300003], [-122.03193419599995, 48.21407180700004], [-122.0295357, 48.21461432400008], [-122.028331692, 48.21496648400006]]
```
After:
```python
>>> from prereise.gather.griddata.hifld import const
>>> from prereise.gather.griddata.hifld.data_access import load
>>> lines = load.get_hifld_electric_power_transmission_lines(const.blob_paths["transmission_lines"])
>>> lines.iloc[0]["COORDINATES"]
[(48.18834609800007, -122.11300327699996), (48.18844025300007, -122.11224433699999), (48.18846523700006, -122.11179104899998), (48.188868556000045, -122.11164471199999), (48.18946104200006, -122.10942467499996), (48.19038189300005, -122.10576625399995), (48.19083161100008, -122.10404590399997), (48.19118139200003, -122.10268604199996), (48.191877384000065, -122.09992348699996), (48.19261620700007, -122.09708954899997), (48.19340856700006, -122.09405573699996), (48.19400105300008, -122.09192135999996), (48.19522885500004, -122.08790602), (48.195828479000056, -122.08597151799995), (48.196375755000076, -122.08413005299997), (48.19659466600007, -122.08322585799999), (48.19769635600005, -122.07983274599997), (48.20000443300006, -122.07226130099997), (48.201360726000075, -122.07046242899997), (48.20268846500005, -122.06871590499998), (48.20419228500003, -122.06671239799999), (48.204125660000045, -122.06214859199997), (48.20403524000005, -122.05664727799996), (48.206528915000035, -122.05160757999994), (48.20927957200007, -122.046039641), (48.210388401000046, -122.04373632299996), (48.21212064900004, -122.04032417599996), (48.21338176300003, -122.03485617399997), (48.21407180700004, -122.03193419599995), (48.21461432400008, -122.0295357), (48.21496648400006, -122.028331692)]
```

### Time estimate
5 minutes.
