### PR TITLE
refactor: change transmission processing code to expect (lat, lon) instead of (lon, lat)

### DIFF
--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -106,13 +106,13 @@ def filter_lines_with_nonmatching_substation_coords(lines, substations, threshol
     # Coordinates are initially (lon, lat); we reverse to (lat, lon) for haversine
     start_subs = lines.apply(
         lambda x: find_closest_substation_and_distance(
-            x.loc["COORDINATES"][0][::-1], x.loc["SUB_1"], substations_groupby
+            x.loc["COORDINATES"][0], x.loc["SUB_1"], substations_groupby
         ),
         axis=1,
     )
     end_subs = lines.apply(
         lambda x: find_closest_substation_and_distance(
-            x.loc["COORDINATES"][-1][::-1], x.loc["SUB_2"], substations_groupby
+            x.loc["COORDINATES"][-1], x.loc["SUB_2"], substations_groupby
         ),
         axis=1,
     )


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
This is a follow-up to #223. Now that we have points as (lat, lon) instead of (lon, lat), we need to change the code that uses coordinates.

### What the code is doing
Undoing the list reversal `[::-1]`.

### Testing
Manually.

### Usage Example
Before, all lines are dropped because they're evaluated as 'mismatches', since the (lat, lon) location is very far away from the (lon, lat) location:
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> lines, substations = build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
dropping 759 lines with one or more substations listed as 'NOT AVAILABLE' out of a starting total of 71554
dropping 3143 lines with one or more substations not found in substations table out of a starting total of 70795
Evaluating endpoint location mismatches... (this may take several minutes)
dropping 67652 lines with one or more substations with non-matching coordinates out of a starting total of 67652
dropping 0 lines with matching SUB_1 and SUB_2 out of a starting total of 0
```
After, the previous behavior is restored:
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> lines, substations = build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
dropping 759 lines with one or more substations listed as 'NOT AVAILABLE' out of a starting total of 71554
dropping 3143 lines with one or more substations not found in substations table out of a starting total of 70795
Evaluating endpoint location mismatches... (this may take several minutes)
dropping 120 lines with one or more substations with non-matching coordinates out of a starting total of 67652
dropping 143 lines with matching SUB_1 and SUB_2 out of a starting total of 67532
2119 line voltages can't be found via neighbor consensus
310 line voltages can't be found via neighbor minimum
```

### Time estimate
2 minutes.
