### PR TITLE
feat: add heat rate parameter estimation

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -346,3 +346,30 @@ fuel_prices = {  # EIA Annual Energy Outlook, values for 2022, $/MMBTu (2020 USD
     "SUB": 2.02,  # SUB-bituminous coal
     "WC": 2.02,  # Waste Coal
 }
+
+# Values from EPA's Power Sector Modeling Platform v6 - Summer 2021 Reference Case
+reasonable_heat_rates_size_cutoffs = {
+    ("Natural Gas Fired Combustion Turbine", "GT"): 80,
+    ("Petroleum Liquids", "GT"): 80,
+    ("Petroleum Liquids", "IC"): 5,
+}
+reasonable_heat_rates_by_type = {
+    ("Conventional Steam Coal", "ST"): (8.3, 14.5),
+    ("Natural Gas Fired Combined Cycle", "CA"): (5.5, 15.0),
+    ("Natural Gas Fired Combined Cycle", "CS"): (5.5, 15.0),
+    ("Natural Gas Fired Combined Cycle", "CT"): (5.5, 15.0),
+    ("Natural Gas Internal Combustion Engine", "IC"): (8.7, 18.0),
+    ("Natural Gas Steam Turbine", "ST"): (8.3, 14.5),
+    ("Petroleum Coke", "ST"): (8.3, 14.5),
+    ("Petroleum Liquids", "CA"): (6.0, 15.0),
+    ("Petroleum Liquids", "CT"): (6.0, 15.0),
+    ("Petroleum Liquids", "ST"): (8.3, 14.5),
+}
+reasonable_heat_rates_by_type_and_size = {
+    ("Natural Gas Fired Combustion Turbine", "GT", "small"): (8.7, 36.8),
+    ("Natural Gas Fired Combustion Turbine", "GT", "large"): (8.7, 18.7),
+    ("Petroleum Liquids", "GT", "small"): (6.0, 36.8),
+    ("Petroleum Liquids", "GT", "large"): (6.0, 25.0),
+    ("Petroleum Liquids", "IC", "small"): (8.7, 42.5),
+    ("Petroleum Liquids", "IC", "large"): (8.7, 20.5),
+}

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -112,6 +112,7 @@ blob_paths = {
     "substations": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Substations_Jul2020.csv",
     "transmission_lines": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Power_Transmission_Lines_Jul2020.geojson.zip",
 }
+eia_epa_crosswalk_path = "https://raw.githubusercontent.com/Breakthrough-Energy/camd-eia-crosswalk/master/epa_eia_crosswalk.csv"
 
 volt_class_defaults = {
     "UNDER 100": 69,

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -322,3 +322,10 @@ state_county_splits = {
         "Western": {"EL PASO", "HUDSPETH"},
     },
 }
+
+heat_rate_estimation_columns = [
+    "ORISPL_CODE",
+    "UNITID",
+    "GLOAD (MW)",
+    "HEAT_INPUT (mmBtu)",
+]

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -373,3 +373,15 @@ reasonable_heat_rates_by_type_and_size = {
     ("Petroleum Liquids", "IC", "small"): (8.7, 42.5),
     ("Petroleum Liquids", "IC", "large"): (8.7, 20.5),
 }
+
+heat_rate_assumptions = {
+    "Conventional Hydroelectric": 0,
+    "Geothermal": 0,
+    "Hydroelectric Pumped Storage": 0,
+    "Nuclear": 10.5,  # From EIA's Electric Power Annual 2019, Table 8.1
+    "Offshore Wind Turbine": 0,
+    "Onshore Wind Turbine": 0,
+    "Solar Photovoltaic": 0,
+    "Solar Thermal with Energy Storage": 0,
+    "Solar Thermal without Energy Storage": 0,
+}

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -330,3 +330,19 @@ heat_rate_estimation_columns = [
     "GLOAD (MW)",
     "HEAT_INPUT (mmBtu)",
 ]
+
+fuel_prices = {  # EIA Annual Energy Outlook, values for 2022, $/MMBTu (2020 USD)
+    "BIT": 2.02,  # BITuminous coal
+    "DFO": 17.85,  # Distillate Fuel Oil
+    "JF": 11.41,  # Jet Fuel
+    "KER": 11.41,  # KERosene
+    "LIG": 2.02,  # LIGnite coal
+    "NG": 3.60,  # Natural Gas
+    "NUC": 0.69,  # NUClear (uranium)
+    "PC": 2.02,  # Petroleum Coke
+    "PG": 15.43,  # Propane (Gaseous)
+    "RC": 2.02,  # Residual Coal
+    "RFO": 9.75,  # Residual Fuel Oil
+    "SUB": 2.02,  # SUB-bituminous coal
+    "WC": 2.02,  # Waste Coal
+}

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -24,6 +24,30 @@ def get_eia_form_860(path):
     return data.query("State in @abv2state")
 
 
+def get_eia_epa_crosswalk(path):
+    """Read a CSV file mapping EIA plants IDs to EPA plant IDs, keep non-retired plants.
+
+    :param str path: path to file. Either local or URL.
+    :return: (*pandas.DataFrame*) -- filtered data frame.
+    """
+    crosswalk_match_exclude = {"CAMD Unmatched", "Manual CAMD Excluded"}  # noqa: F841
+    data = (
+        pd.read_csv(path)
+        .query(
+            "MATCH_TYPE_GEN not in @crosswalk_match_exclude and CAMD_STATUS != 'RET'"
+        )
+        .astype(
+            {
+                "MOD_EIA_PLANT_ID": int,
+                "MOD_CAMD_UNIT_ID": "string",
+                "MOD_CAMD_GENERATOR_ID": "string",
+                "MOD_EIA_GENERATOR_ID_GEN": "string",
+            }
+        )
+    )
+    return data
+
+
 def get_epa_ampd(path, years={2019}, cache=False):
     """Read a collection of zipped CSV files from the EPA AMPD dataset and keep readings
     from plants located in contiguous states.

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -9,7 +9,8 @@ from zipfile import ZipFile
 import pandas as pd
 from tqdm import tqdm
 
-from prereise.gather.griddata.hifld.const import abv2state  # noqa F401
+from prereise.gather.griddata.hifld.const import abv2state  # noqa: F401
+from prereise.gather.griddata.hifld.const import heat_rate_estimation_columns
 
 
 def get_eia_form_860(path):
@@ -75,7 +76,8 @@ def get_epa_ampd(path, year=2019, cache=False):
                     )
             else:
                 df = pd.read_csv(
-                    path_sep.join([path, filename]), usecols=heat_rate_estimation_columns,
+                    path_sep.join([path, filename]),
+                    usecols=heat_rate_estimation_columns,
                 )
             data[state][month_num] = df
     joined = pd.concat(

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -82,7 +82,7 @@ def get_epa_ampd(path, year=2019, cache=False):
         [data[state][month_num] for state in abv2state for month_num in range(1, 13)]
     )
 
-    return joined
+    return joined.astype({"UNITID": "string"})
 
 
 def get_epa_needs(path):

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -24,12 +24,12 @@ def get_eia_form_860(path):
     return data.query("State in @abv2state")
 
 
-def get_epa_ampd(path, year=2019, cache=False):
+def get_epa_ampd(path, years={2019}, cache=False):
     """Read a collection of zipped CSV files from the EPA AMPD dataset and keep readings
     from plants located in contiguous states.
 
     :param str path: path to folder. Either local or URL.
-    :param str year: year of data to read (will be present in filenames)
+    :param iterable years: years of data to read (will be present in filenames).
     :param bool cache: Whether to locally cache the EPA AMPD data, and read from the
         cache when it's available.
     :return: (*pandas.DataFrame*) -- readings from operational power plant in contiguous
@@ -52,36 +52,42 @@ def get_epa_ampd(path, year=2019, cache=False):
         cache_dir = os.path.join(os.path.dirname(__file__), "cache")
         os.makedirs(cache_dir, exist_ok=True)
 
-    data = {state: {} for state in abv2state}
-    for state in tqdm(abv2state):
-        for month_num in range(1, 13):
-            filename = f"{year}{state.lower()}{str(month_num).rjust(2, '0')}.zip"
-            if cache:
-                try:
-                    df = pd.read_csv(
-                        os.path.join(cache_dir, filename),
-                        usecols=heat_rate_estimation_columns,
-                    )
-                except Exception:
+    data = {year: {state: {} for state in abv2state} for year in years}
+    for year in sorted(years):
+        for state in tqdm(abv2state):
+            for month_num in range(1, 13):
+                filename = f"{year}{state.lower()}{str(month_num).rjust(2, '0')}.zip"
+                if cache:
+                    try:
+                        df = pd.read_csv(
+                            os.path.join(cache_dir, filename),
+                            usecols=heat_rate_estimation_columns,
+                        )
+                    except Exception:
+                        df = pd.read_csv(
+                            path_sep.join([path, filename]),
+                            usecols=heat_rate_estimation_columns,
+                        )
+                        df.to_csv(
+                            os.path.join(cache_dir, filename),
+                            compression={
+                                "method": "zip",
+                                "archive_name": filename.replace(".zip", ".csv"),
+                            },
+                        )
+                else:
                     df = pd.read_csv(
                         path_sep.join([path, filename]),
                         usecols=heat_rate_estimation_columns,
                     )
-                    df.to_csv(
-                        os.path.join(cache_dir, filename),
-                        compression={
-                            "method": "zip",
-                            "archive_name": filename.replace(".zip", ".csv"),
-                        },
-                    )
-            else:
-                df = pd.read_csv(
-                    path_sep.join([path, filename]),
-                    usecols=heat_rate_estimation_columns,
-                )
-            data[state][month_num] = df
+                data[year][state][month_num] = df
     joined = pd.concat(
-        [data[state][month_num] for state in abv2state for month_num in range(1, 13)]
+        [
+            data[year][state][month_num]
+            for year in sorted(years)
+            for state in abv2state
+            for month_num in range(1, 13)
+        ]
     )
 
     return joined.astype({"UNITID": "string"})

--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -192,6 +192,8 @@ def build_plant(bus, substations, kwargs={}):
     generators["Pmax"] = generators[
         ["Summer Capacity (MW)", "Winter Capacity (MW)"]
     ].max(axis=1)
+    # Drop generators with no capacity listed
+    generators = generators.loc[~generators["Pmax"].isnull()]
     generators.rename({"Minimum Load (MW)": "Pmin"}, inplace=True, axis=1)
     print("Fitting heat rate curves to EPA data... (this may take several minutes)")
     heat_rate_curve_estimates = generators.apply(

--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -320,5 +320,14 @@ def build_plant(bus, substations, kwargs={}):
     generators = generators.join(heat_rate_curve_estimates)
     filter_suspicious_heat_rates(generators)
     augment_missing_heat_rates(generators)
+    # Drop generators whose heat rates can't be estimated
+    to_be_dropped = generators.query("h1.isnull()")
+    print(
+        f"Dropping generators whose heat rates can't be estimated: {len(to_be_dropped)}"
+        f" out of {len(generators)}, {round(to_be_dropped['Pmax'].sum(), 0)} MW out of "
+        f"{round(generators['Pmax'].sum(), 0)} total MW"
+    )
+    print(to_be_dropped.groupby(["Technology", "Prime Mover"])["Pmax"].sum())
+    generators.drop(to_be_dropped.index, inplace=True)
 
     return generators

--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from powersimdata.utility.distance import haversine
+from scipy.optimize import curve_fit
 
 from prereise.gather.griddata.hifld import const
 from prereise.gather.griddata.hifld.data_access import load
@@ -84,18 +85,68 @@ def map_generator_to_bus_by_sub(generator, bus_groupby):
         return bus_groupby.get_group(generator.sub_id)["baseKV"].idxmin()
 
 
-def build_plant(bus, substations):
+def estimate_heat_rate_curve(
+    generator, epa_ampd_groupby, crosswalk_translation, min_unique_x=3, min_points=24
+):
+    """Estimate a generator's heat rate curve if data are present in the EPA AMPD data,
+    otherwise return NA.
+
+    :param pandas.Series generator: one generating unit from data frame.
+    :param pandas.GroupBy epa_ampd_groupby: data frame of EPA AMPD samples, grouped by
+        plant ID and unit ID.
+    :param pandas.Series crosswalk_translation: mapping of EIA keys to EPA keys.
+    :param int min_unique_x: minimum number of unique x points needed to fit a curve to.
+    :param int min_points: minimum number points needed to fit a curve to.
+    :return: (*tuple*) -- if possible, quadratic coefficients:
+        c0 (constant), c1 (linear), and c2 (quadratic); respectively. Otherwise, return
+        NA values for each
+    """
+
+    def quadratic(x, a, b, c):
+        return a + b * x + c * x ** 2
+
+    quadratic_coefficient_bounds = ([0] * 3, [float("inf")] * 3)
+    return_index = ["h0", "h1", "h2"]
+    default_return = pd.Series([float("nan")] * 3, index=return_index)
+    eia_key = (generator["Plant Code"], generator["Generator ID"])
+    x_col = "GLOAD (MW)"
+    y_col = "HEAT_INPUT (mmBtu)"
+    try:
+        epa_key = crosswalk_translation.loc[eia_key].values[0]
+        samples = epa_ampd_groupby.get_group(epa_key)
+        filtered_samples = samples.query(
+            f"(not `{x_col}`.isnull()) and `{x_col}` != 0 "
+            f"and (not `{y_col}`.isnull()) and `{y_col}` != 0"
+        )
+        if len(filtered_samples[x_col].unique()) < min_unique_x:
+            return default_return
+        if len(filtered_samples) < min_points:
+            return default_return
+        xs = filtered_samples[x_col]
+        ys = filtered_samples[y_col]
+        popt, _ = curve_fit(quadratic, xs, ys, bounds=quadratic_coefficient_bounds)
+        return pd.Series(popt, index=return_index)
+    except KeyError:
+        return default_return
+
+
+def build_plant(bus, substations, kwargs={}):
     """Use source data on generating units from EIA/EPA, along with transmission network
     data, to produce a plant data frame.
 
     :param pandas.DataFrame bus: data frame of buses, to be used within
         :func:`map_generator_to_bus_by_sub`.
     :param pandas.DataFrame substations: data frame of substations.
+    :param dict kwargs: keyword arguments to be passed to lower level-functions,
+        i.e. :func:`estimate_heat_rate_curve`.
     :return: (*pandas.DataFrame*) -- data frame of generator data.
     """
     # Initial loading
     generators = load.get_eia_form_860(const.blob_paths["eia_form860_2019_generator"])
     plants = load.get_eia_form_860(const.blob_paths["eia_form860_2019_plant"])
+    print("Fetching EPA data... (this may take several minutes)")
+    epa_ampd = load.get_epa_ampd(const.blob_paths["epa_ampd"])
+    crosswalk = load.get_eia_epa_crosswalk(const.eia_epa_crosswalk_path)
 
     # Data interpretation
     plants = plants.set_index("Plant Code")
@@ -103,6 +154,14 @@ def build_plant(bus, substations):
     plants["Longitude"] = plants["Longitude"].map(floatify)
     for col in ["Summer Capacity (MW)", "Winter Capacity (MW)", "Minimum Load (MW)"]:
         generators[col] = generators[col].map(floatify)
+    crosswalk_translation = (
+        crosswalk.set_index(["MOD_EIA_PLANT_ID", "MOD_CAMD_GENERATOR_ID"])
+        .apply(
+            lambda x: (x["CAMD_PLANT_ID"], x["MOD_CAMD_UNIT_ID"]),
+            axis=1,
+        )
+        .sort_index()
+    )
 
     # Filtering / Grouping
     generators = generators.query(
@@ -112,6 +171,7 @@ def build_plant(bus, substations):
     # Filter substations with no buses
     substations = substations.loc[set(bus_groupby.groups.keys())]
     substation_groupby = substations.groupby(["interconnect", "ZIP"])
+    epa_ampd_groupby = epa_ampd.groupby(["ORISPL_CODE", "UNITID"])
 
     # Add information
     generators["interconnect"] = (
@@ -133,5 +193,13 @@ def build_plant(bus, substations):
         ["Summer Capacity (MW)", "Winter Capacity (MW)"]
     ].max(axis=1)
     generators.rename({"Minimum Load (MW)": "Pmin"}, inplace=True, axis=1)
+    print("Fitting heat rate curves to EPA data... (this may take several minutes)")
+    heat_rate_curve_estimates = generators.apply(
+        lambda x: estimate_heat_rate_curve(
+            x, epa_ampd_groupby, crosswalk_translation, **kwargs
+        ),
+        axis=1,
+    )
+    generators = generators.join(heat_rate_curve_estimates)
 
     return generators

--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -122,6 +122,7 @@ def build_plant(bus, substations):
     generators["lat"] = generators["Plant Code"].map(plants["Latitude"])
     generators["lon"] = generators["Plant Code"].map(plants["Longitude"])
     generators["ZIP"] = generators["Plant Code"].map(plants["Zip"])
+    print("Mapping generators to substations... (this may take several minutes)")
     generators["sub_id"] = generators.apply(
         lambda x: map_generator_to_sub_by_location(x, substation_groupby), axis=1
     )

--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -329,5 +329,9 @@ def build_plant(bus, substations, kwargs={}):
     )
     print(to_be_dropped.groupby(["Technology", "Prime Mover"])["Pmax"].sum())
     generators.drop(to_be_dropped.index, inplace=True)
+    # Add fuel costs, calculate cost curves from heat rate curves
+    generators["GenFuelCost"] = generators["Energy Source 1"].map(const.fuel_prices)
+    for i in range(3):
+        generators[f"c{i}"] = generators[f"h{i}"] * generators["GenFuelCost"].fillna(0)
 
     return generators

--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -309,6 +309,7 @@ def build_plant(bus, substations, kwargs={}):
     # Drop generators with no capacity listed
     generators = generators.loc[~generators["Pmax"].isnull()]
     generators.rename({"Minimum Load (MW)": "Pmin"}, inplace=True, axis=1)
+    generators["Pmin"] = generators["Pmin"].fillna(0)
     print("Fitting heat rate curves to EPA data... (this may take several minutes)")
     heat_rate_curve_estimates = generators.apply(
         lambda x: estimate_heat_rate_curve(

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ packages = find:
 python_requires = >=3.7
 
 [options.package_data]
-prereise = gather/*/data/*, gather/data/*
+prereise = gather/*/data/*, gather/*/*/data/*, gather/data/*


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add code to estimate heat rate curves from EPA AMPD data. See #222 for more context.

### What the code is doing
- Within **load.py**, we add a new function `get_eia_epa_crosswalk` to get the EIA/EPA crosswalk CSV as a dataframe with columns interpreted properly. We also modify the `get_epa_ampd` function to only use a subset of columns, to be able to cut down on the large memory requirements for loading all of the EPA data into memory.
- Within **generators.py**, we add a new primary function `estimate_heat_rate_curve`. Within this function, we check if there is an EIA/EPA crosswalk mapping available, and if there are enough non-null data points available to fit a curve to (if no to either, return NA). If so, we use the small helper function `estimate_quadratic_curve` to estimate quadratic curve parameters, with each bounded to be non-negative (based on an intuitive understanding of generator physical properties). Within `build_plant`, we prepare inputs to this primary function and call it.
- Within **setup.py**, we ensure that the files in the `prereise/gather/griddata/hifld/data` folder get copied when PreREISE is installed (unrelated fix).

### Testing
Tested manually.

### Usage Example/Visuals
```python
>>> from prereise.gather.griddata.hifld.data_process.generators import build_plant
>>> from prereise.gather.griddata.hifld.data_process.transmission import (
...     build_transmission,
...     create_buses,
... )
>>> lines, substations = build_transmission()
>>> bus = create_buses(lines)
>>> generators = build_plant(bus, substations)
```

We have a lot of generators whose coefficients can't be mapped this way, but many of them we wouldn't expect to be mapped this way (based on technology), and the by-capacity coverage is 84%:
```python
>>> columns_of_interest = [
...     "Plant Code",
...     "Generator ID",
...     "Technology",
...     "lat",
...     "lon",
...     "interconnect",
...     "sub_id",
...     "bus_id",
...     "Pmax",
...     "Pmin",
...     "c0",
...     "c1",
...     "c2",
... ]
>>> generators[columns_of_interest].isna().sum()
Plant Code          0
Generator ID        0
Technology          0
lat                 0
lon                 0
interconnect        0
sub_id            383
bus_id            383
Pmax               72
Pmin             3975
c0              18076
c1              18076
c2              18076
dtype: int64
>>> no_ampd_expected_techs = {
...     "Batteries",
...     "Conventional Hydroelectric",
...     "Flywheels",
...     "Geothermal",
...     "Hydroelectric Pumped Storage",
...     "Nuclear",
...     "Offshore Wind Turbine",
...     "Onshore Wind Turbine",
...     "Solar Photovoltaic",
...     "Solar Thermal with Energy Storage",
...     "Solar Thermal without Energy Storage",
... }
>>> (
...     generators.loc[~generators["c0"].isna(), "Pmax"].sum()
...     / generators.loc[~generators["Technology"].isin(no_ampd_expected_techs), "Pmax"].sum()
... )
0.8412704125821295
```
Of the generator types with a lot of capacity missing, the type with the worst coverage (natural gas open-loop CT) still has 80% coverage by capacity, so we should be able to reasonably extrapolate to fill in these generators.

One of the discussions of fitting quadratic vs. linear heat rate curves was that the fitted curves might not have significant quadratic components, but we see a good mix of linear-only fits and meaningful quadratics. Out of about 3,700 generators, there are 1300-1400 with effectively zero quadratic component (depending on rounding precision), but the median quadratic coefficients is 3e-3, with a fairly long tail:
```python
>>> gens_with_coefficients = generators.loc[~generators["c0"].isna()]
>>> len(gens_with_coefficients)
3739
>>> (gens_with_coefficients["c2"] >= 1e-3).sum()
2209
>>> gens_with_coefficients["c2"].median()
0.0030797879396536106
>>> gens_with_coefficients["c2"].mean()
0.036075623706129496
>>> gens_with_coefficients["c2"].hist(range=(0,0.2), bins=200,cumulative=True)
<AxesSubplot:>
>>> plt.xlabel("c2")
Text(0.5, 0, 'c2')
>>> plt.ylabel("Count (cumulative)")
Text(0, 0.5, 'Count (cumulative)')
>>> plt.show()
```
![c2](https://user-images.githubusercontent.com/7348392/134190890-f22a9a2e-67e4-4b70-80f6-d4da4ebbcfd7.png)

### Broader context
As discussed in #222, we may eventually want to aggregate some combined units together into one unit, since the CT and ST parts aren't really operationally independent. I think we should be able to refactor this new feature to do so fairly easily, by adding another column to the `generators` dataframe to represent generator groupings, and then refactoring `estimate_heat_rate_curve` to take a group of generator samples as input (summing the sample points by timestamp as applicable), rather than a single generator's samples, if/when we decide that we want to group and how the groups should be defined.

### Time estimate
30 minutes.
