### PR TITLE
docs: improve section on documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ third party dependencies.
 
 
 ## Documentation
-The official documentation can be found [here][docs].
+[Code documentation][docstrings] in form of Python docstrings along with an overview of
+the [package][docs] are available on our [website][website].
 
 
 ## Communication Channels
@@ -72,5 +73,7 @@ Guide](https://breakthrough-energy.github.io/docs/dev/contribution_guide.html).
 
 
 
-[docs]: https://breakthrough-energy.github.io/docs/index.html
+[docs]: https://breakthrough-energy.github.io/docs/prereise/index.html
+[docstrings]: https://breakthrough-energy.github.io/docs/prereise.html
+[website]: https://breakthrough-energy.github.io/docs/
 [PowerSimData]: https://github.com/Breakthrough-Energy/PowerSimData


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

Add links to docstrings and package overview in README. 

### What the code is doing
N/A

### Testing
N/A

### Where to look
In the **Documentation** section of the README

### Usage Example/Visuals
You can take a look [here](https://github.com/Breakthrough-Energy/PreREISE/blob/ben/readme/README.md).

### Time estimate
2min