### PR TITLE
feat: add function to assign demand to buses proportional to population

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -447,4 +447,36 @@ The data are used to populate the power generation profile of U.S. transmission 
 ##### Note
 Public use (see https://hifld-geoplatform.opendata.arcgis.com/datasets/geoplatform::power-plants/about). Users are advised to read the data set's metadata thoroughly to understand appropriate use and data limitations.
 
+
+##### Source
+* Name: U.S. Zips
+* Author: Pareto Software, LLC
+* Description: Data on United States ZIP codes
+* Source: https://simplemaps.com
+* Exact source location: https://simplemaps.com/data/us-zips
+* Note: version 1.78, accessed 2021-10-27.
+
+##### Destination
+* Modifications to source file(s): None
+* Location: https://besciences.blob.core.windows.net/datasets/geo_data/uszips.csv
+
+##### General Purpose
+The data are used to estimate population served by each substation, to distribute demand.
+
+
+##### Source
+* Name: U.S. Counties
+* Author: Pareto Software, LLC
+* Description: Data on United States counties
+* Source: https://simplemaps.com
+* Exact source location: https://simplemaps.com/data/us-counties
+* Note: version 1.71, accessed 2021-10-27.
+
+##### Destination
+* Modifications to source file(s): None
+* Location: https://besciences.blob.core.windows.net/datasets/geo_data/uscounties.csv
+
+##### General Purpose
+The data are used to estimate population served by each substation, to distribute demand.
+
 ---

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -111,6 +111,8 @@ blob_paths = {
     "epa_needs": "https://besciences.blob.core.windows.net/datasets/EPA_NEEDS/needs-v620_06-30-21-2_active.csv",
     "substations": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Substations_Jul2020.csv",
     "transmission_lines": "https://besciences.blob.core.windows.net/datasets/hifld/Electric_Power_Transmission_Lines_Jul2020.geojson.zip",
+    "us_counties": "https://besciences.blob.core.windows.net/datasets/geo_data/uscounties.csv",
+    "us_zips": "https://besciences.blob.core.windows.net/datasets/geo_data/uszips.csv",
 }
 eia_epa_crosswalk_path = "https://raw.githubusercontent.com/Breakthrough-Energy/camd-eia-crosswalk/master/epa_eia_crosswalk.csv"
 
@@ -386,6 +388,7 @@ heat_rate_assumptions = {
     "Solar Thermal without Energy Storage": 0,
 }
 
+
 # These lines were manually identified based on a combination of: their 'TYPE'
 # classification, their substation names, and their geographical paths. The capacities
 # for each line were compiled from a variety of public sources.
@@ -402,3 +405,6 @@ dc_line_ratings = {  # MW
     310053: 400,  # Trans-Bay Cable
     311958: 5,  # Alamogordo Solar Energy Center
 }
+
+substation_load_share = 0.5
+demand_per_person = 2.01e-3

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -231,3 +231,21 @@ def get_zone(path):
     :return: (*pandas.DataFrame*) -- information related to load zone
     """
     return pd.read_csv(path, index_col="zone_id")
+
+
+def get_us_counties(path):
+    """Read the file containing county data.
+
+    :param str path: path to file. Either local or URL.
+    :return: (*pandas.DataFrame*) -- information related to counties
+    """
+    return pd.read_csv(path).set_index("county_fips")
+
+
+def get_us_zips(path):
+    """Read the file containing ZIP code data.
+
+    :param str path: path to file. Either local or URL.
+    :return: (*pandas.DataFrame*) -- information related to ZIP codes
+    """
+    return pd.read_csv(path, dtype={"zip": "string"}).set_index("zip")

--- a/prereise/gather/griddata/hifld/data_process/demand.py
+++ b/prereise/gather/griddata/hifld/data_process/demand.py
@@ -1,0 +1,76 @@
+import pandas as pd
+
+from prereise.gather.griddata.hifld import const
+from prereise.gather.griddata.hifld.data_access.load import get_us_counties, get_us_zips
+
+
+def assign_demand_to_buses(substations, branch, plant, bus):
+    """Using data on population by county and ZIP code, assign demand to substations,
+    then to the lowest-voltage bus within each substation.
+    This demand parameter is added inplace as a 'Pd' column to the ``bus`` data frame.
+
+    :param pandas.DataFrame substations: table of substation data.
+    :param pandas.DataFrame branch: table of branch data.
+    :param pandas.DataFrame plant: table of plant data.
+    :param pandas.DataFrame bus: table of bus data.
+    """
+    # Load data
+    zip_data = get_us_zips(const.blob_paths["us_zips"])
+    county_data = get_us_counties(const.blob_paths["us_counties"])
+
+    # Determine each substation's transmission capacity, then sort for selection
+    filtered_branch = branch.query("SUB_1_ID != SUB_2_ID")
+    from_cap = filtered_branch.groupby("SUB_1_ID").sum()["rateA"]
+    to_cap = filtered_branch.groupby("SUB_2_ID").sum()["rateA"]
+    sub_cap = from_cap.combine(to_cap, lambda x, y: x + y, fill_value=0)
+    # Sort substations by their capacities for later ordered selection
+    sorted_subs = substations.loc[sub_cap.sort_values(ascending=False).index].copy()
+
+    # Determine for each ZIP, how much demand to assign to each load substation
+    # Assume here that generator substations don't have load attached to them
+    filtered_subs = sorted_subs.loc[~sorted_subs.index.isin(plant["sub_id"])]
+    subs_per_zip = filtered_subs.value_counts("ZIP")
+    zip_load_substations = subs_per_zip * const.substation_load_share
+    zip_load_substations = zip_load_substations.round().clip(lower=1)
+    zip_assigned_population = (zip_data["population"] / zip_load_substations).dropna()
+    # Select the N substations per ZIP with greatest transmission capacity
+    load_substations = pd.concat(
+        df.head(int(zip_load_substations[name]))
+        for name, df in filtered_subs.groupby("ZIP")
+    )
+    substations["pop_ZIP"] = load_substations["ZIP"].map(zip_assigned_population)
+
+    # Assign remaining county population to substations with load already,
+    # plus the most connected substation in any county without a load substation.
+    load_subs_from_zips = substations.query("pop_ZIP > 0")
+    load_subs_per_county = load_subs_from_zips.value_counts("COUNTYFIPS")
+    county_pop = county_data["population"]
+
+    # Select the one substation per missing county with greatest transmission capacity
+    counties_without_load_subs = set(county_pop.index) - set(load_subs_per_county.index)
+    subs_in_counties_without_load_subs = sorted_subs.loc[
+        sorted_subs["COUNTYFIPS"].isin(counties_without_load_subs)
+    ]
+    added_load_subs = pd.concat(
+        df.head(1)
+        for name, df in subs_in_counties_without_load_subs.groupby("COUNTYFIPS")
+    )
+    load_subs = pd.concat([load_subs_from_zips, added_load_subs])
+    load_subs_per_county = load_subs_per_county.reindex(county_pop.index).fillna(1)
+
+    # Distribute population remaining after ZIP distribution to identified load buses
+    distributed_pop = load_subs.groupby("COUNTYFIPS")["pop_ZIP"].sum()
+    remaining_pop = county_pop - distributed_pop.reindex(county_pop.index).fillna(0)
+    remaining_pop_per_sub = remaining_pop.clip(lower=0) / load_subs_per_county
+    # We may still miss some population, since there may be a county without any
+    # substations, but we should cover the vast majority.
+    substations["pop_county"] = load_subs["COUNTYFIPS"].map(remaining_pop_per_sub)
+
+    # Translate population to demand
+    total_pop = substations["pop_ZIP"].fillna(0) + substations["pop_county"].fillna(0)
+    sub_demand = total_pop * const.demand_per_person
+
+    load_buses = pd.concat(
+        df.head(1) for sub_id, df in bus.sort_values("baseKV").groupby("sub_id")
+    )
+    bus["Pd"] = load_buses["sub_id"].map(sub_demand).reindex(bus.index).fillna(0)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Estimates population per substation, using data from simplemaps.com, and uses this information to add demand to buses. This is a re-implementation of the approach taken by the collaborators. Closes #229. 

### What the code is doing

We add a new module `prereise.gather.griddata.hifld.data_process.demand` with a single function `assign_demand_to_buses`. This function:
1. Loads population by ZIP and by county from CSVs in the repo.
2. Sorts substations by connected transmission capacity.
3. Distributes each ZIP code's population to the N highest-transmission-capacity non-generation substations within that ZIP, where N is an integer value less than the total (calculated using the `substation_load_share` fraction within **const.py**) but no less than one, unless there are no substations within that ZIP. These are considered as 'load substations'.
4. Determines which counties have no substations with ZIP-assigned demand ('load substations'), and for each of these, picks the substation in the county with greatest transmission capacity to add to the set of load substations.
5. Determines how much of each county's population is not yet assigned, and distributes this to the load substations within the county. Note: if a county has no substations at all, its population does not go anywhere else, and is effectively ignored. Less than 5% of population is ignored this way, so it should not have a large effect on the overall demand distribution.
6. Translates total population (from ZIP-assignment and county assignment) to demand using an assumption of demand-per-person.
7. Selects the lowest-voltage bus within each substation to assign demand to.

Besides **demand.py**, all other changes are data/documentation.

### Testing
Tested manually.

### Usage Example/Visuals
```python
import pandas as pd
from prereise.gather.griddata.hifld.data_process.demand import assign_demand_to_buses
from prereise.gather.griddata.hifld.data_process.generators import build_plant
from prereise.gather.griddata.hifld.data_process.transmission import (
    build_transmission,
    calculate_branch_mileage,
    create_buses,
    create_transformers,
    estimate_branch_impedance,
    estimate_branch_rating,
)

# Invoking highest-level `data_process` functions
lines, substations = build_transmission(method="line2sub")
bus = create_buses(lines)
generators = build_plant(bus, substations)

# This code has been demonstrated via other PRs, but hasn't been baked into the top-level data process functions yet
lines["type"] = "Line"
lines["length"] = lines.apply(calculate_branch_mileage, axis=1)
transformers = create_transformers(bus)
transformers["type"] = "Transformer"
branch = pd.concat([lines, transformers])
branch["x"] = branch.apply(lambda x: estimate_branch_impedance(x, bus["baseKV"]), axis=1)
branch["rateA"] = branch.apply(lambda x: estimate_branch_rating(x, bus["baseKV"]), axis=1)

# New code
assign_demand_to_buses(substations, branch, generators, bus)
```

A `"Pd"` column is added inplace to the `bus` dataframe:
```python
>>> # Estimated 2.01 kW per person within code, 315.8 million people assigned to buses
>>> bus["Pd"].sum() / 2.01e-3
315800868.4704517
>>> bus["Pd"].isna().sum()
0
```

We need the generators to be able to preferentially assign demand to non-generator buses, and we need branch capacities to preferentially assign demand to higher-capacity substations when multiple substations are available within an area (ZIP or county). Generating the transformers and estimating branch impedances and capacities should probably be added to `build_transmission` as part of fulfillment of #226.

I demonstrate using the "line2sub" method since I have more faith in line coordinates than line substation names, based on some exploration with DC lines: https://github.com/Breakthrough-Energy/PreREISE/issues/233#issuecomment-954154337. I suggest that we also switch to this as default as part of #226.

### Time estimate
1 hour. The code itself isn't too long, but it's some fairly dense pandas.
