### PR TITLE
feat: filter DC lines out of AC transmission network processing within HIFLD construction

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -385,3 +385,20 @@ heat_rate_assumptions = {
     "Solar Thermal with Energy Storage": 0,
     "Solar Thermal without Energy Storage": 0,
 }
+
+# These lines were manually identified based on a combination of: their 'TYPE'
+# classification, their substation names, and their geographical paths. The capacities
+# for each line were compiled from a variety of public sources.
+dc_line_ratings = {  # MW
+    108354: 500,  # Square Butte
+    113313: 660,  # Neptune Cable
+    131914: 2000,  # Quebec – New England Transmission (Ayer to Monroe)
+    150123: 1000,  # CU
+    157627: 330,  # Cross-Sound Cable
+    157629: 660,  # Hudson Project
+    158515: 2000,  # Quebec – New England Transmission (Quebec to Monroe)
+    200823: 3100,  # Pacific DC Intertie (Path 65)
+    308464: 2400,  # Intermountain Power Project (Path 27)
+    310053: 400,  # Trans-Bay Cable
+    311958: 5,  # Alamogordo Solar Energy Center
+}

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -604,6 +604,22 @@ def estimate_branch_rating(branch, bus_voltages):
     raise ValueError(f"{branch.loc['type']} not a valid branch type")
 
 
+def split_lines_to_ac_and_dc(lines, dc_override_indices=None):
+    """Given a data frame of mixed AC & DC lines, where some DC lines are not
+    appropriately labeled, split into an AC data frame and a DC data frame.
+
+    :param pandas.DataFrame lines: combined data frame of AC & DC lines.
+    :param iterable dc_override_indices: indices to coerce to DC classification.
+    :return: (*tuple*) -- two data frames, of AC & DC lines, respectively.
+    """
+    if dc_override_indices is None:
+        dc_override_indices = {}
+    dc_types = {"DC; OVERHEAD", "DC; UNDERGROUND"}  # noqa: F841
+    dc_lines = lines.query("TYPE in @dc_types or index in @dc_override_indices")
+    ac_lines = lines.query("index not in @dc_lines.index")
+    return ac_lines.copy(), dc_lines.copy()
+
+
 def build_transmission(method="line2sub", **kwargs):
     """Build transmission network
 

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -604,7 +604,7 @@ def estimate_branch_rating(branch, bus_voltages):
     raise ValueError(f"{branch.loc['type']} not a valid branch type")
 
 
-def build_transmission(method="sub2line", **kwargs):
+def build_transmission(method="line2sub", **kwargs):
     """Build transmission network
 
     :param str method: method used to build network. Default method is *sub2line*


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Partial fulfilment of #233: this addresses the HVDC transmission lines within the HIFLD dataset, but does not yet address the B2Bs, which will require a different method of splitting substations into sub-substations for each interconnection.

### What the code is doing
In **const.py**, ratings are added for DC lines with known capacities.

In **transmission.py**:
- A small helper function `split_lines_to_ac_and_dc` is added to filter out DC lines via some combination of the `TYPE` attribute of the HIFLD dataset and manually specified indices.
- `build_transmission` uses this function, then adds impedances and AC ratings to AC branches only (using functionality introduced in #218 and #219), and uses the pre-defined ratings from **const.py** to add capacities to the DC lines.

### Testing
Tested manually.

### Usage Example/Visuals
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> branch, substations, dc_lines = build_transmission()
dropping 6892 substations of 70857 total due to LINES parameter equal to 0
filter substations based on lines
---------------------------------
assigning substations to lines' endpoints by mapping their rounded (3 digits) coordinates
dropping 3314 lines having same endpoints coordinates after rounding
finding closest substation to unmapped lines' endpoint(s)
100%|███████████████████████████████████| 2624/2624 [00:00<00:00, 19820.94it/s]
dropping 0 lines due to island size filtering
dropping 0 substations due to island size filtering
Reading cached minimum spanning tree
2948 line voltages can't be found via neighbor consensus
No more missing voltages remain after neighbor minimum
>>> branch.columns
Index(['TYPE', 'STATUS', 'NAICS_CODE', 'NAICS_DESC', 'SOURCE', 'SOURCEDATE',
       'VAL_METHOD', 'VAL_DATE', 'OWNER', 'VOLTAGE', 'VOLT_CLASS', 'INFERRED',
       'SUB_1', 'SUB_2', 'COORDINATES', 'SUB_1_ID', 'SUB_2_ID', 'type',
       'length', 'from_bus_id', 'to_bus_id', 'x', 'rateA'],
      dtype='object')
>>> dc_lines.columns
Index(['TYPE', 'STATUS', 'NAICS_CODE', 'NAICS_DESC', 'SOURCE', 'SOURCEDATE',
       'VAL_METHOD', 'VAL_DATE', 'OWNER', 'VOLTAGE', 'VOLT_CLASS', 'INFERRED',
       'SUB_1', 'SUB_2', 'COORDINATES', 'SUB_1_ID', 'SUB_2_ID', 'Pmax',
       'Pmin'],
      dtype='object')
>>> dc_lines["Pmax"]
200823    3100
308464    2400
310053     400
311958       5
157627     330
157629     660
158515    2000
108354     500
113313     660
131914    2000
Name: Pmax, dtype: int64
```

Branch entries get impedance (`x`) and rating, DC lines get `Pmax` and `Pmin`.

### Time estimate
15 minutes.
