### PR TITLE
fix: various issues with HIFLD transmission loading/processing

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -408,3 +408,10 @@ dc_line_ratings = {  # MW
 
 substation_load_share = 0.5
 demand_per_person = 2.01e-3
+
+contiguous_us_bounds = {
+    "east": -66,
+    "north": 50,
+    "south": 25,
+    "west": -125,
+}

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -221,7 +221,7 @@ def get_hifld_electric_power_transmission_lines(path):
     # Replace dummy data with explicit 'missing'
     properties.loc[properties.VOLTAGE == -999999, "VOLTAGE"] = pd.NA
 
-    return properties.query("STATUS == 'IN SERVICE'")
+    return properties.query("STATUS == 'IN SERVICE' or STATUS == 'NOT AVAILABLE'")
 
 
 def get_zone(path):

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -10,7 +10,10 @@ import pandas as pd
 from tqdm import tqdm
 
 from prereise.gather.griddata.hifld.const import abv2state  # noqa: F401
-from prereise.gather.griddata.hifld.const import heat_rate_estimation_columns
+from prereise.gather.griddata.hifld.const import (
+    contiguous_us_bounds,
+    heat_rate_estimation_columns,
+)
 
 
 def get_eia_form_860(path):
@@ -217,6 +220,16 @@ def get_hifld_electric_power_transmission_lines(path):
     properties["COORDINATES"] = properties["COORDINATES"].map(
         lambda x: [y[::-1] for y in x]
     )
+
+    within_bounding_box = properties["COORDINATES"].apply(
+        lambda x: (
+            (contiguous_us_bounds["south"] < x[0][0] < contiguous_us_bounds["north"])
+            & (contiguous_us_bounds["west"] < x[0][1] < contiguous_us_bounds["east"])
+            & (contiguous_us_bounds["south"] < x[-1][0] < contiguous_us_bounds["north"])
+            & (contiguous_us_bounds["west"] < x[-1][1] < contiguous_us_bounds["east"])
+        )
+    )
+    properties = properties.loc[within_bounding_box]
 
     # Replace dummy data with explicit 'missing'
     properties.loc[properties.VOLTAGE == -999999, "VOLTAGE"] = pd.NA

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -356,8 +356,10 @@ def filter_islands_and_connect_with_mst(
     # Connect selected connected components
     mst_edges = get_mst_edges(lines, substations, **kwargs)
 
+    first_new_id = lines.index.max() + 1
     new_lines = pd.DataFrame(
-        [{"SUB_1_ID": x[2]["start"], "SUB_2_ID": x[2]["end"]} for x in mst_edges]
+        [{"SUB_1_ID": x[2]["start"], "SUB_2_ID": x[2]["end"]} for x in mst_edges],
+        index=pd.RangeIndex(first_new_id, first_new_id + len(mst_edges)),
     )
     new_lines = new_lines.assign(VOLTAGE=pd.NA, VOLT_CLASS="NOT AVAILABLE")
     new_lines["COORDINATES"] = new_lines.apply(
@@ -700,6 +702,8 @@ def build_transmission(method="line2sub", **kwargs):
     # Add transformers, and calculate rating and impedance for all branches
     transformers = create_transformers(bus)
     transformers["type"] = "Transformer"
+    first_new_id = ac_lines.index.max() + 1
+    transformers.index = pd.RangeIndex(first_new_id, first_new_id + len(transformers))
     ac_lines["type"] = "Line"
     ac_lines["length"] = ac_lines.apply(calculate_branch_mileage, axis=1)
     branch = pd.concat([ac_lines, transformers])

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -88,13 +88,13 @@ def map_lines_to_substations_using_coords(
     subcoord = list(subcoord2subid)
     missing_points = set().union(
         *[
-            set(line2sub.loc[line2sub[e_sub].isna(), e].apply(lambda x: (x[1], x[0])))
+            set(line2sub.loc[line2sub[e_sub].isna(), e].map(tuple))
             for e, e_sub in end_sub.items()
         ]
     )
-    tree = KDTree([ll2uv(p[0], p[1]) for p in subcoord])
+    tree = KDTree([ll2uv(p[1], p[0]) for p in subcoord])
     endpoint2neighbor = {
-        (p[1], p[0]): subcoord2subid[subcoord[tree.query(ll2uv(p[0], p[1]))[1]]]
+        p: subcoord2subid[subcoord[tree.query(ll2uv(p[1], p[0]))[1]]]
         for p in tqdm(missing_points, total=len(missing_points))
     }
     filled_subs = [


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Various fixes for processing of HIFLD transmission data:
- Correct a lat/lon vs. lon/lat issue (and add a test for said issue) when mapping lines to substations
- In addition to lines whose status is `IN SERVICE`, also return lines whose status is `NOT AVAILABLE`, since this represents most of the lines in the Rocky Mountain states (see https://github.com/Breakthrough-Energy/PreREISE/issues/233#issuecomment-960081829).
- Using a rough bounding box of the contiguous U.S., don't return lines for which at least one end is outside of this box (e.g. Alaska, Hawaii, Puerto Rico)
- Ensure that indices aren't duplicated within the branch dataframe as a results of concatenating individual dataframes for [original lines, MST-connecting lines, transformers]

### What the code is doing
- In **const.py**, we add data for a rough bounding box for the contiguous U.S. states.
- In **load.py**, we use this bounding box to filter lines, and we return both `IN SERVICE` and `NOT AVAILABLE` lines.
- In **transmission.py**:
  - within `map_lines_to_substations_using_coords`, we fix a lat/lon vs. lon/lat bug.
  - within `filter_islands_and_connect_with_mst`, we add a meaningful index to the new lines.
  - within `build_transmission`, we add a meaningful index to the new transformers.
 - In **test_transmission.py**, we add a test (`test_map_lines_to_substations_using_coords`) that catches the lat/lon vs. lon/lat issue as well as tests the combining of substations via coordinate rounding.

### Testing
The new unit test initially fails due to the lat/lon issue, but passes once the fix is added.

### Usage Example/Visuals
Before:
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> branch, bus, substations, dc_lines = build_transmission()
>>> len(branch)
74859
>>> branch.index.duplicated().sum()
522
```
After:
```python
>>> from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
>>> branch, bus, substations, dc_lines = build_transmission()
>>> len(branch)
93908
>>> branch.index.duplicated().sum()
0
```

After the changes, we have many more branches, and no duplicate indices.

### Time estimate
30 minutes.
