### PR TITLE
feat: separate interconnections via network topology

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -534,3 +534,5 @@ b2b_ratings = {  # MW
     "UNKNOWN304994": 600,  # Welsh (Eastern/ERCOT)
     "VIRGINIA SMITH CONVERTER STATION": 200,  # a.k.a. 'Sidney' (Eastern/Western)
 }
+
+interconnect_size_rank = ["Eastern", "Western", "ERCOT"]

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -415,3 +415,56 @@ contiguous_us_bounds = {
     "south": 25,
     "west": -125,
 }
+
+seams_substations = {
+    "east_west": {
+        202364,  # 'LAMAR HVDC TIE'
+        202159,  # 'UNKNOWN202159', NE (effecitvely Sidney/Virginia Smith)
+        202160,  # 'VIRGINIA SMITH CONVERTER STATION'
+        202177,  # Sidney-adjacent
+        202178,  # 'STEGAL', NE
+        131797,  # Stegal-adjacent
+        203572,  # 'MILES CITY', MT (the substation that appears more likely to be the real one)
+        203590,  # 'RICHARDSON COULEE' (near MALTA, shouldn't be necessary?)
+        303738,  # 'BLACKWATER TIE', NM
+        304165,  # 'EDDY AC-DC-AC TIE', NM
+        # Rapid City Disconnections
+        131171,  # North of Rapid City
+        131176,  # North of Rapid City
+        202567,  # East of Rapid City
+        # Highline NE/CO border
+        205884,  # Julesburg, CO
+        205888,  # Holyoke, CO
+        203719,  # 'ALVIN' substation
+    },
+    "east_ercot": {
+        161924,  # Logansport, TX
+        300490,  # Vernon, TX
+        301314,  # Valley Lake, TX connection to OK
+        301729,  # Hawkins, TX
+        302012,  # Vernon, TX
+        302274,  # 'COTTONWOOD', Glenn, TX
+        303004,  # Crowell, TX
+        303646,  # San Augustine, TX
+        303719,  # Big Sandy, TX
+        304100,  # Matador, TX
+        304328,  # Midland, TX
+        304477,  # Oklaunion substation (B2B)
+        304825,  # Dennison, TX connection to OK
+        304391,  # Long Branch, TX
+        304994,  # Welsh substation (B2B)
+        306058,  # Munday, TX
+        306638,  # Pittsburg, TX
+        306738,  # Henderson, TX
+        307121,  # Kirkland, TX
+        307363,  # Navasota, TX
+        307539,  # Mt. Pleasant, TX
+        307735,  # Shiro, TX
+        308062,  # Lufkin, TX
+        308951,  # Beckville, TX
+        308976,  # Dayton, TX
+        309403,  # Kilgore, TX
+        310861,  # Overton, TX
+        310879,  # Huntsville, TX
+    },
+}

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -468,3 +468,57 @@ seams_substations = {
         310879,  # Huntsville, TX
     },
 }
+
+substation_interconnect_assumptions = {
+    "Eastern": {
+        131171,
+        131172,
+        131853,
+        161925,
+        167678,
+        167679,
+        167681,
+        167682,
+        167684,
+        307364,
+    },
+    "Western": {
+        201396,
+        202172,
+        205667,
+        205889,
+        205890,
+    },
+    "ERCOT": {
+        301181,
+        301291,
+        302826,
+        303024,  # Substations between East/ERCOT AC connector and Oklaunion B2B station
+        303394,
+        303406,
+        303433,
+        304994,  # Welsh B2B
+        309433,
+        309658,
+    },
+}
+
+line_interconnect_assumptions = {
+    "Eastern": {
+        128641,
+        132264,
+        135527,
+        141367,
+        300170,
+        301858,
+        303906,
+        305887,
+        306332,
+        306885,
+        310668,
+        311279,
+        311520,
+    },
+    "Western": {123525, 141873},
+    "ERCOT": {305330, 309428, 310121},
+}

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -522,3 +522,15 @@ line_interconnect_assumptions = {
     "Western": {123525, 141873},
     "ERCOT": {305330, 309428, 310121},
 }
+
+b2b_ratings = {  # MW
+    "BLACKWATER TIE": 200,  # a.k.a. 'Clovis'/'Roosevelt County' (Eastern/Western)
+    "EDDY AC-DC-AC TIE": 200,  # a.k.a. 'Artesia' (Eastern/Western)
+    "LAMAR HVDC TIE": 210,  # (Eastern/Western)
+    "MILES CITY": 200,  # (Eastern/Western)
+    "NEW UNDERWOOD": 200,  # representative of the Rapid City DC Tie (Eastern/Western)
+    "STEGALL": 110,  # (Eastern/Western)
+    "UNKNOWN304477": 220,  # Oklaunion (Eastern/ERCOT)
+    "UNKNOWN304994": 600,  # Welsh (Eastern/ERCOT)
+    "VIRGINIA SMITH CONVERTER STATION": 200,  # a.k.a. 'Sidney' (Eastern/Western)
+}

--- a/prereise/gather/griddata/hifld/data/zone.csv
+++ b/prereise/gather/griddata/hifld/data/zone.csv
@@ -3,53 +3,55 @@ zone_id,zone_name,state,interconnect,time_zone
 2,Arkansas,Arkansas,Eastern,ETC/GMT+6
 3,Arizona,Arizona,Western,ETC/GMT+7
 4,California,California,Western,ETC/GMT+8
-5,Colorado,Colorado,Western,ETC/GMT+7
-6,Connecticut,Connecticut,Eastern,ETC/GMT+5
-7,Delaware,Delaware,Eastern,ETC/GMT+5
-8,Florida,Florida,Eastern,ETC/GMT+6
-9,Georgia,Georgia,Eastern,ETC/GMT+5
-10,Iowa,Iowa,Eastern,ETC/GMT+6
-11,Idaho,Idaho,Western,ETC/GMT+7
-12,Illinois,Illinois,Eastern,ETC/GMT+6
-13,Indiana,Indiana,Eastern,ETC/GMT+5
-14,Kansas,Kansas,Eastern,ETC/GMT+6
-15,Kentucky,Kentucky,Eastern,ETC/GMT+5
-16,Louisiana,Louisiana,Eastern,ETC/GMT+6
-17,Massachusetts,Massachusetts,Eastern,ETC/GMT+5
-18,Maryland,Maryland,Eastern,ETC/GMT+5
-19,Maine,Maine,Eastern,ETC/GMT+5
-20,Michigan,Michigan,Eastern,ETC/GMT+5
-21,Minnesota,Minnesota,Eastern,ETC/GMT+6
-22,Missouri,Missouri,Eastern,ETC/GMT+6
-23,Mississippi,Mississippi,Eastern,ETC/GMT+6
-24,Montana Eastern,Montana,Eastern,ETC/GMT+7
-25,Montana Western,Montana,Western,ETC/GMT+7
-26,North Carolina,North Carolina,Eastern,ETC/GMT+5
-27,North Dakota,North Dakota,Eastern,ETC/GMT+6
-28,Nebraska,Nebraska,Eastern,ETC/GMT+6
-29,New Hampshire,New Hampshire,Eastern,ETC/GMT+5
-30,New Jersey,New Jersey,Eastern,ETC/GMT+5
-31,New Mexico Eastern,New Mexico,Eastern,ETC/GMT+7
-32,New Mexico Western,New Mexico,Western,ETC/GMT+7
-33,Nevada,Nevada,Western,ETC/GMT+8
-34,New York,New York,Eastern,ETC/GMT+5
-35,Ohio,Ohio,Eastern,ETC/GMT+5
-36,Oklahoma,Oklahoma,Eastern,ETC/GMT+6
-37,Oregon,Oregon,Western,ETC/GMT+8
-38,Pennsylvania,Pennsylvania,Eastern,ETC/GMT+5
-39,Rhode Island,Rhode Island,Eastern,ETC/GMT+5
-40,South Carolina,South Carolina,Eastern,ETC/GMT+5
-41,South Dakota Eastern,South Dakota,Eastern,ETC/GMT+6
-42,South Dakota Western,South Dakota,Western,ETC/GMT+6
-43,Tennessee,Tennessee,Eastern,ETC/GMT+6
-44,Texas Eastern,Texas,Eastern,ETC/GMT+6
-45,Texas Panhandle,Texas,Eastern,ETC/GMT+6
-46,ERCOT,Texas,Texas,ETC/GMT+6
-47,El Paso,Texas,Western,ETC/GMT+7
-48,Utah,Utah,Western,ETC/GMT+7
-49,Virginia,Virginia,Eastern,ETC/GMT+5
-50,Vermont,Vermont,Eastern,ETC/GMT+5
-51,Washington,Washington,Western,ETC/GMT+8
-52,Wisconsin,Wisconsin,Eastern,ETC/GMT+6
-53,West Virginia,West Virginia,Eastern,ETC/GMT+5
-54,Wyoming,Wyoming,Western,ETC/GMT+7
+5,Colorado Western,Colorado,Western,ETC/GMT+7
+6,Colorado Eastern,Colorado,Eastern,ETC/GMT+7
+7,Connecticut,Connecticut,Eastern,ETC/GMT+5
+8,Delaware,Delaware,Eastern,ETC/GMT+5
+9,Florida,Florida,Eastern,ETC/GMT+6
+10,Georgia,Georgia,Eastern,ETC/GMT+5
+11,Iowa,Iowa,Eastern,ETC/GMT+6
+12,Idaho,Idaho,Western,ETC/GMT+7
+13,Illinois,Illinois,Eastern,ETC/GMT+6
+14,Indiana,Indiana,Eastern,ETC/GMT+5
+15,Kansas,Kansas,Eastern,ETC/GMT+6
+16,Kentucky,Kentucky,Eastern,ETC/GMT+5
+17,Louisiana,Louisiana,Eastern,ETC/GMT+6
+18,Massachusetts,Massachusetts,Eastern,ETC/GMT+5
+19,Maryland,Maryland,Eastern,ETC/GMT+5
+20,Maine,Maine,Eastern,ETC/GMT+5
+21,Michigan,Michigan,Eastern,ETC/GMT+5
+22,Minnesota,Minnesota,Eastern,ETC/GMT+6
+23,Missouri,Missouri,Eastern,ETC/GMT+6
+24,Mississippi,Mississippi,Eastern,ETC/GMT+6
+25,Montana Eastern,Montana,Eastern,ETC/GMT+7
+26,Montana Western,Montana,Western,ETC/GMT+7
+27,North Carolina,North Carolina,Eastern,ETC/GMT+5
+28,North Dakota,North Dakota,Eastern,ETC/GMT+6
+29,Nebraska Eastern,Nebraska,Eastern,ETC/GMT+6
+30,Nebraska Western,Nebraska,Western,ETC/GMT+6
+31,New Hampshire,New Hampshire,Eastern,ETC/GMT+5
+32,New Jersey,New Jersey,Eastern,ETC/GMT+5
+33,New Mexico Eastern,New Mexico,Eastern,ETC/GMT+7
+34,New Mexico Western,New Mexico,Western,ETC/GMT+7
+35,Nevada,Nevada,Western,ETC/GMT+8
+36,New York,New York,Eastern,ETC/GMT+5
+37,Ohio,Ohio,Eastern,ETC/GMT+5
+38,Oklahoma,Oklahoma,Eastern,ETC/GMT+6
+39,Oregon,Oregon,Western,ETC/GMT+8
+40,Pennsylvania,Pennsylvania,Eastern,ETC/GMT+5
+41,Rhode Island,Rhode Island,Eastern,ETC/GMT+5
+42,South Carolina,South Carolina,Eastern,ETC/GMT+5
+43,South Dakota Eastern,South Dakota,Eastern,ETC/GMT+6
+44,South Dakota Western,South Dakota,Western,ETC/GMT+6
+45,Tennessee,Tennessee,Eastern,ETC/GMT+6
+46,Texas Eastern,Texas,Eastern,ETC/GMT+6
+47,Texas Panhandle,Texas,Eastern,ETC/GMT+6
+48,ERCOT,Texas,Texas,ETC/GMT+6
+49,El Paso,Texas,Western,ETC/GMT+7
+50,Utah,Utah,Western,ETC/GMT+7
+51,Virginia,Virginia,Eastern,ETC/GMT+5
+52,Vermont,Vermont,Eastern,ETC/GMT+5
+53,Washington,Washington,Western,ETC/GMT+8
+54,Wisconsin,Wisconsin,Eastern,ETC/GMT+6
+55,West Virginia,West Virginia,Eastern,ETC/GMT+5
+56,Wyoming,Wyoming,Western,ETC/GMT+7

--- a/prereise/gather/griddata/hifld/data_access/load.py
+++ b/prereise/gather/griddata/hifld/data_access/load.py
@@ -181,7 +181,9 @@ def get_hifld_electric_substations(path):
         .round({"MAX_VOLT": 3, "MIN_VOLT": 3})
     )
 
-    return data.query("STATUS == 'IN SERVICE' and STATE in @abv2state")
+    return data.query(
+        "(STATUS == 'IN SERVICE' or STATUS == 'NOT AVAILABLE') and STATE in @abv2state"
+    )
 
 
 def get_hifld_electric_power_transmission_lines(path):

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -110,7 +110,7 @@ def map_lines_to_substations_using_coords(
     }
     for a in all2one:
         type2id = substations.loc[list(a)].reset_index().groupby("TYPE").first()["ID"]
-        for t in ["SUBSTATION", "TAP", "RISER", "DEAD END"]:
+        for t in ["SUBSTATION", "TAP", "RISER", "DEAD END", "NOT AVAILABLE"]:
             try:
                 all2one[a] = type2id.loc[t]
                 break


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
- Load substations whose status is either `IN SERVICE` or `NOT AVAILABLE`. Although `NOT AVAILABLE` substations are only about 5% of the total, they're about 20% of the substations within Texas and New Mexico, which causes lines to get mapped to faraway substations which are sometimes in other interconnections.
- Add a function which can separate and label the `interconnect` attribute of lines and substations, given input on where to split the substations and how to re-join them.
- Add data that when input into the new function, splits the HIFLD network into three interconnections. This data is imperfect, especially regarding the Eastern/ERCOT seam around Lubbock and the Texas panhandle more broadly, but it demonstrates how the new function works and should be able to be revised later without any code changes.

Closes #233.

### What the code is doing
- **const.py** gets the (imperfect) information which splits the interconnection into different networks.
- **topology.py** gets the new function `add_interconnects_by_connected_components` that:
  - Builds a NetworkX graph of the network once a subset of substations (and all lines connected to them) are removed.
  - Labels the lines of the connected components based on assumptions of size (Eastern > Western > ERCOT).
  - Labels lines based on user-supplied information (assumptions for lines & substations).
  - Labels lines based on the interconnects of their neighbors at non-dropped substations.
  - Using the `interconnect` labels for lines, identify which interconnects are present within substations that get split, and create new pseudo-substations for each interconnect within a substation, and re-connect lines as necessary. New pseudo-substations get added, and substations which got split are removed.
  - Labels the substations based on the new topology.
 - **transmission.py** uses this new function to assign interconnects to lines & substations, rather than the assumptions by county as previously.

### Testing
Tested manually:
```python
from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
branch, bus, substations, dclines = build_transmission()
```

Validation:
```python
>>> import networkx as nx
>>> g = nx.convert_matrix.from_pandas_edgelist(
...     branch.query("not SUB_1_ID.isnull()"), "SUB_1_ID", "SUB_2_ID",
... )
>>> interconnects = list(nx.connected_components(g))
>>> sorted_interconnects = sorted(interconnects, key=len)[::-1]
>>> for s in sorted_interconnects:
...     print(f"connected component with {len(s)} substations")
...     print("substations:", substations.loc[s].value_counts("interconnect"))
...     print("lines:", branch.query("SUB_1_ID in @s or SUB_2_ID in @s").value_counts("interconnect"))
...
connected component with 45141 substations
substations: interconnect
Eastern    45141
dtype: int64
lines: interconnect
Eastern    62046
dtype: int64
connected component with 12983 substations
substations: interconnect
Western    12983
dtype: int64
lines: interconnect
Western    17910
dtype: int64
connected component with 3352 substations
substations: interconnect
ERCOT    3352
dtype: int64
lines: interconnect
ERCOT    4980
dtype: int64
```

### Usage Example/Visuals

Here are the transmission lines for the states required to define the interconnections, colored by interconnect, with tiny yellow stars at the location of the dropped substations:
![map_all_substations_reconnected_reduced](https://user-images.githubusercontent.com/7348392/142076902-aaa008bf-f577-48a6-883e-d0ad66c86a50.png)

### Time estimate
30-60 minutes for the current code/logic. I'm also going to add some tests and try to factor out some of the for loops that were added for convenience but could probably be equivalently done in a cleaner way, although the elapsed time for these steps is quite short so it doesn't need too much optimization.