### PR TITLE
refactor/feat: decouple HRRR wind profile generation from Grid object, add individual calculation

### DIFF
--- a/prereise/gather/winddata/const.py
+++ b/prereise/gather/winddata/const.py
@@ -1,0 +1,12 @@
+# Power curve constants
+wspd_height_base = 262.467  # 80m in feet
+wspd_exp = 0.15  # wspd(h) = wspd_0 * (h / h0)**wspd_exp
+new_curve_res = 0.01  # resolution: m/s
+offshore_hub_height = 393.701  # 120 meters, in feet
+max_wind_speed = 30  # m/s
+
+# EIA Form 860 Table 3.3 names
+mfg_col = "Predominant Turbine Manufacturer"
+model_col = "Predominant Turbine Model Number"
+capacity_col = "Nameplate Capacity (MW)"
+hub_height_col = "Turbine Hub Height (Feet)"

--- a/prereise/gather/winddata/hrrr/calculations.py
+++ b/prereise/gather/winddata/hrrr/calculations.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from prereise.gather.winddata.hrrr.helpers import formatted_filename
 from prereise.gather.winddata.impute import linear
-from prereise.gather.winddata.rap.power_curves import (
+from prereise.gather.winddata.power_curves import (
     get_power,
     get_state_power_curves,
     get_turbine_power_curves,

--- a/prereise/gather/winddata/hrrr/calculations.py
+++ b/prereise/gather/winddata/hrrr/calculations.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pandas as pd
 import pygrib
@@ -27,7 +29,7 @@ def get_wind_data_lat_long(dt, directory):
     :return: (*tuple*) -- A tuple of 2 same lengthed numpy arrays, first one being
         latitude and second one being longitude.
     """
-    gribs = pygrib.open(directory + formatted_filename(dt))
+    gribs = pygrib.open(os.path.join(directory, formatted_filename(dt)))
     grib = next(gribs)
     return grib.latlons()
 
@@ -84,7 +86,7 @@ def extract_wind_speed(wind_farms, start_dt, end_dt, directory):
     # Fetch wind speed data for each wind farm (or store NaN as applicable)
     wind_speed_data = pd.DataFrame(index=dts, columns=wind_farms.index, dtype=float)
     for dt in tqdm(dts):
-        gribs = pygrib.open(formatted_filename(dt))
+        gribs = pygrib.open(os.path.join(directory, formatted_filename(dt)))
         try:
             u_component = gribs.select(name=U_COMPONENT_SELECTOR)[0].values.flatten()
             v_component = gribs.select(name=V_COMPONENT_SELECTOR)[0].values.flatten()

--- a/prereise/gather/winddata/hrrr/calculations.py
+++ b/prereise/gather/winddata/hrrr/calculations.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pygrib
-from powersimdata.network.usa_tamu.constants.zones import id2abv
 from powersimdata.utility.distance import ll2uv
 from scipy.spatial import KDTree
 from tqdm import tqdm
@@ -69,7 +68,7 @@ def calculate_pout(wind_farms, start_dt, end_dt, directory):
     :meth:`prereise.gather.winddata.hrrr.hrrr.retrieve_data` with the same
     start_dt, end_dt, and directory.
 
-    :param pandas.DataFrame wind_farms: plant data frame.
+    :param pandas.DataFrame wind_farms: plant data frame, plus 'state_abv' column.
     :param str start_dt: start date.
     :param str end_dt: end date (inclusive).
     :param str directory: directory where hrrr data is contained.
@@ -79,11 +78,13 @@ def calculate_pout(wind_farms, start_dt, end_dt, directory):
             wind_farm1  wind_farm2
         dt1    POUT        POUT
         dt2    POUT        POUT
+    :raises ValueError: if ``wind_farms`` is missing the 'state_abv' column.
     """
 
+    if "state_abv" not in wind_farms.columns:
+        raise ValueError("The wind_farms data frame must have a 'state_abv' column")
     turbine_types = wind_farms.apply(
-        lambda x: "Offshore" if x["type"] == "wind_offshore" else id2abv[x["zone_id"]],
-        axis=1,
+        lambda x: "Offshore" if x["type"] == "wind_offshore" else x["state_abv"], axis=1
     )
 
     turbine_power_curves = get_turbine_power_curves()

--- a/prereise/gather/winddata/hrrr/tests/test_calculations.py
+++ b/prereise/gather/winddata/hrrr/tests/test_calculations.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from prereise.gather.winddata.hrrr.calculations import (
-    calculate_pout,
+    calculate_pout_blended,
     find_closest_wind_grids,
 )
 
@@ -30,7 +30,7 @@ def test_find_closest_wind_grids():
 @patch("prereise.gather.winddata.hrrr.calculations.get_wind_data_lat_long")
 @patch("prereise.gather.winddata.hrrr.calculations.find_closest_wind_grids")
 @patch("prereise.gather.winddata.hrrr.calculations.pygrib")
-def test_calculate_pout(
+def test_calculate_pout_blended(
     pygrib, find_closest_wind_grids, get_wind_data_lat_long, get_power
 ):
     # we assume get_power is well tested and simply return the magnitude value passed in
@@ -58,7 +58,7 @@ def test_calculate_pout(
     wind_farms.loc.__getitem__.return_value.type = "wind_offshore"
     wind_farms.loc.__getitem__.return_value.state_abv = "MA"
     wind_farms.__len__.return_value = 2
-    df = calculate_pout(
+    df = calculate_pout_blended(
         wind_farms,
         datetime.fromisoformat("2016-01-01"),
         datetime.fromisoformat("2016-01-01"),

--- a/prereise/gather/winddata/hrrr/tests/test_calculations.py
+++ b/prereise/gather/winddata/hrrr/tests/test_calculations.py
@@ -53,8 +53,10 @@ def test_calculate_pout(
     )
     pygrib.open.return_value = grib_mock
     wind_farms = MagicMock()
+    wind_farms.columns = ["type", "state_abv"]
     wind_farms.index = [0, 1]
     wind_farms.loc.__getitem__.return_value.type = "wind_offshore"
+    wind_farms.loc.__getitem__.return_value.state_abv = "MA"
     wind_farms.__len__.return_value = 2
     df = calculate_pout(
         wind_farms,

--- a/prereise/gather/winddata/impute.py
+++ b/prereise/gather/winddata/impute.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from prereise.gather.winddata.rap.power_curves import (
+from prereise.gather.winddata.power_curves import (
     get_power,
     get_state_power_curves,
     get_turbine_power_curves,

--- a/prereise/gather/winddata/rap/rap.py
+++ b/prereise/gather/winddata/rap/rap.py
@@ -8,12 +8,12 @@ from powersimdata.network.usa_tamu.constants.zones import id2abv
 from powersimdata.utility.distance import angular_distance, ll2uv
 from tqdm import tqdm
 
-from prereise.gather.winddata.rap.noaa_api import NoaaApi
-from prereise.gather.winddata.rap.power_curves import (
+from prereise.gather.winddata.power_curves import (
     get_power,
     get_state_power_curves,
     get_turbine_power_curves,
 )
+from prereise.gather.winddata.rap.noaa_api import NoaaApi
 
 
 def retrieve_data(wind_farm, start_date="2016-01-01", end_date="2016-12-31"):

--- a/prereise/gather/winddata/tests/test_power_curves.py
+++ b/prereise/gather/winddata/tests/test_power_curves.py
@@ -6,16 +6,16 @@ import numpy as np
 import pandas as pd
 from numpy.testing import assert_array_almost_equal
 
-from prereise.gather.winddata.rap.power_curves import (
-    _shift_turbine_curve,
+from prereise.gather.winddata.power_curves import (
     build_state_curves,
     get_form_860,
     get_power,
     get_state_power_curves,
     get_turbine_power_curves,
+    shift_turbine_curve,
 )
 
-data_dir = path.abspath(path.join(path.dirname(__file__), "..", "..", "data"))
+data_dir = path.abspath(path.join(path.dirname(__file__), "..", "data"))
 
 
 def _first_one(curve):
@@ -111,7 +111,7 @@ class TestShiftTurbineCurve(unittest.TestCase):
 
     def test_shift_turbine_curve_higher_hub(self):
         original = self.power_curves["IEC class 2"]
-        shifted = _shift_turbine_curve(
+        shifted = shift_turbine_curve(
             original, hub_height=270, maxspd=26, new_curve_res=0.01
         )
         self._check_curve_structure(shifted, maxspd=26, new_curve_res=0.01)
@@ -120,7 +120,7 @@ class TestShiftTurbineCurve(unittest.TestCase):
 
     def test_shift_turbine_curve_lower_hub(self):
         original = self.power_curves["IEC class 2"]
-        shifted = _shift_turbine_curve(
+        shifted = shift_turbine_curve(
             original, hub_height=260, maxspd=29, new_curve_res=0.02
         )
         self._check_curve_structure(shifted, maxspd=29, new_curve_res=0.02)
@@ -129,7 +129,7 @@ class TestShiftTurbineCurve(unittest.TestCase):
 
     def test_shift_turbine_curve_sameheight_hub(self):
         original = self.power_curves["IEC class 2"]
-        shifted = _shift_turbine_curve(
+        shifted = shift_turbine_curve(
             original, hub_height=262.467, maxspd=30, new_curve_res=0.05
         )
         self._check_curve_structure(shifted, maxspd=30, new_curve_res=0.05)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
This partially addresses #213 by decoupling the HRRR wind profile creation from the Grid object and associated network-specific mappings. Instead of assuming that the dataframe passed is from the `usa_tamu` grid, and using the zone-id-to-state-abbreviations from that grid model, we expect a dataframe with a `state_abv` column. This is simpler than what we need for #247, since we don't do interconnection-level blending for states without entries in the EIA wind data table (and therefore don't need grid-level data); we just need the state abbreviation for each wind farm.

This also introduces a new wind profile generation function which uses the individual attributes of each wind farm, since we have this information available if we start from the raw EIA data. The pre-existing function has been renamed from `calculate_pout` to `calculate_pout_blended`, and the new function is named `calculate_pout_individual`. I'm not married to any of these names, in case anyone else has better ideas.

In the process, I also made a couple of other minor changes to the `winddata` sub-module organization.

### What the code is doing
- the `power_curves` sub-module is moved from `prereise.gather.winddata.rap.power_curves` to `prereise.gather.winddata.power_curves`, since it's used within both `prereise.gather.winddata.rap` and `prereise.gather.winddata.hrrr`. Similarly, we add `prereise.gather.winddata.const` for constants that get used throughout the `prereise.gather.winddata` module.
- Within `prereise.gather.winddata.hrrr.calculations`, we:
  - move reading the downloaded grib files and extracting wind speed magnitude to its own function (`extract_wind_speed`)
  - refactor `calculate_pout_blended` to use the new `extract_wind_speed` function, and to get wind farm states directly from the input CSV, rather than assuming a `usa_tamu` grid and getting the mapping from there.
  - add a new function `calculate_pout_individual` to look at the wind-farm-specific attributes passed, build a shifted power curve for each wind farm (shifting based on the real hub height, so that we can use the power curve with NOAA's 80m wind speed data), cache this curve for any subsequent identical queries, and then use the curve to translate wind speed to power.

### Testing
Both functions have been tested manually on the new HIFLD grid. Existing unit tests pass, besides the unrelated 502 Bad Gateway error we've been seeing lately.

### Usage Example/Visuals
Existing blended version:
```python
from datetime import datetime
from powersimdata.input.grid import Grid
from prereise.gather.winddata.hrrr.hrrr import retrieve_data
from prereise.gather.winddata.hrrr.calculations import calculate_pout_blended
start_dt = datetime.fromisoformat("2020-01-01")
end_dt = datetime.fromisoformat("2021-01-01")
directory = "YOUR_DESIRED_DOWNLOAD_DIRECTORY"
grid = Grid("USA", "hifld")
wind_farms = grid.plant.query("type == 'wind' or type == 'wind_offshore'").copy()
wind_farms["state_abv"] = wind_farms.zone_id.map(grid.model_immutables.zones["id2abv"])
retrieve_data(start_dt=start_dt, end_dt=end_dt, directory=directory)
df = calculate_pout_blended(
    wind_farms=wind_farms,
    start_dt=start_dt,
    end_dt=end_dt,
    directory=directory,
)
```

New individual version:
```python
from datetime import datetime
import pandas as pd
from powersimdata.input.grid import Grid
from prereise.gather.winddata.hrrr.hrrr import retrieve_data
from prereise.gather.winddata.hrrr.calculations import calculate_pout_individual

start_dt = datetime.fromisoformat("2020-01-01")
end_dt = datetime.fromisoformat("2021-01-01")
directory = "YOUR_DESIRED_DOWNLOAD_DIRECTORY"
grid = Grid("USA", "hifld")
wind_farms = grid.plant.query("type == 'wind' or type == 'wind_offshore'")

# Read file of wind-farm-specific data
extra_wind_data = pd.read_csv("3_2_Wind_Y2019_Operable.csv")
extra_wind_data.index = extra_wind_data.apply(
    lambda x: f"{x['Plant Code']}_{x['Generator ID']}", axis=1
)

def floatify(x):
    try:
        return float(x)
    except ValueError:
        return float("nan")

# Pre-process wind-farm-specific-data, filling in defaults (262.467 ft = 80m)
extra_wind_data["Turbine Hub Height (Feet)"] = extra_wind_data["Turbine Hub Height (Feet)"].map(floatify).fillna(262.467)
extra_wind_data["Predominant Turbine Manufacturer"] = extra_wind_data["Predominant Turbine Manufacturer"].astype("string").fillna("")
extra_wind_data["Predominant Turbine Model Number"] = extra_wind_data["Predominant Turbine Model Number"].astype("string").fillna("")

joined = wind_farms.join(extra_wind_data, rsuffix="_extra")
retrieve_data(start_dt=start_dt, end_dt=end_dt, directory=directory)
df = calculate_pout_individual(
    wind_farms=joined,
    start_dt=start_dt,
    end_dt=end_dt,
    directory=directory,
)
```

### Time estimate
1 hour. This follows the pattern of #247, but with fewer wrinkles.