### PR TITLE
feat: generate wind profiles during HIFLD grid-building

### DIFF
--- a/prereise/gather/winddata/hrrr/hrrr_api.py
+++ b/prereise/gather/winddata/hrrr/hrrr_api.py
@@ -1,3 +1,5 @@
+import os
+
 import requests
 from pandas import date_range
 from tqdm import tqdm
@@ -83,7 +85,7 @@ class HrrrApi:
                     )
                 )
 
-            with open(directory + filename, "ab") as f:
+            with open(os.path.join(directory, filename), "ab") as f:
                 for grib_record_information in grib_record_information_list:
                     try:
                         self.downloader.download(


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Generate wind profiles at the same time as we build the HIFLD grid, so that we can leverage the plant-specific attributes of each wind farm to generate better profiles (partial fulfillment of #227).

### What the code is doing
- `build_wind` joins the wind-specific data table with the wind plants in the main plant data frame, then calls the individual calculation introduced in #249.
- `create_csvs` is extended with the additional inputs needed by `build_wind`.

### Testing
Tested manually: profiles are created which match the expected timespan, and columns match the indices of wind generators.

### Usage Example/Visuals
```python
def create_csvs(
    DESIRED_OUTPUT_CSV_DIRECTORY,
    wind_directory=YOUR_WIND_CACHE_DIR,
    year=2020,
    YOUR_NREL_EMAIL,
    YOUR_NREL_API_KEY,
    solar_kwargs={"cache_dir": YOUR_SOLAR_CACHE_DIR},
):
```

### Time estimate
30 minutes. This is a draft PR since it depends on #256, but has been tested and performs as expected.
