### PR TITLE
feat: generate hydro profiles during HIFLD grid-building

### DIFF
--- a/prereise/gather/griddata/hifld/data_process/generators.py
+++ b/prereise/gather/griddata/hifld/data_process/generators.py
@@ -298,6 +298,9 @@ def build_plant(bus, substations, kwargs={}):
     generators["lat"] = generators["Plant Code"].map(plants["Latitude"])
     generators["lon"] = generators["Plant Code"].map(plants["Longitude"])
     generators["ZIP"] = generators["Plant Code"].map(plants["Zip"])
+    generators["Balancing Authority Code"] = generators["Plant Code"].map(
+        plants["Balancing Authority Code"]
+    )
     print("Mapping generators to substations... (this may take several minutes)")
     generators["sub_id"] = generators.apply(
         lambda x: map_generator_to_sub_by_location(x, substation_groupby), axis=1

--- a/prereise/gather/griddata/hifld/data_process/profiles.py
+++ b/prereise/gather/griddata/hifld/data_process/profiles.py
@@ -24,12 +24,12 @@ def floatify(x):
         return float("nan")
 
 
-def build_solar(nrel_email, nrel_api_key, solar_plants, **solar_kwargs):
+def build_solar(solar_plants, nrel_email, nrel_api_key, **solar_kwargs):
     """Use plant-level data to build solar profiles.
 
+    :param pandas.DataFrame solar_plants: data frame of solar farms.
     :param str nrel_email: email used to`sign up <https://developer.nrel.gov/signup/>`_.
     :param str nrel_api_key: API key.
-    :param pandas.DataFrame solar_plants: data frame of solar farms.
     :param dict solar_kwargs: keyword arguments to pass to
         :func:`prereise.gather.solardata.nsrdb.sam.retrieve_data_individual`.
     :return: (*pandas.DataFrame*) -- data frame of normalized power profiles. The index
@@ -197,11 +197,11 @@ def parse_eia_to_normalized(hydro_plants, generation, query_regions, year):
     return profiles
 
 
-def build_hydro(eia_api_key, hydro_plants, year, **hydro_kwargs):
+def build_hydro(hydro_plants, eia_api_key, year, **hydro_kwargs):
     """Use plant-level data to build hydro profiles.
 
-    :param str eia_api_key: API key.
     :param pandas.DataFrame hydro_plants: data frame of hydro generators.
+    :param str eia_api_key: API key.
     :param int/str year: year of data to fetch and build profiles for.
     :param dict hydro_kwargs: keyword arguments to pass to
         :func:`prereise.gather.hydrodata.eia.fetch_historical.get_generation`.

--- a/prereise/gather/griddata/hifld/data_process/profiles.py
+++ b/prereise/gather/griddata/hifld/data_process/profiles.py
@@ -1,7 +1,11 @@
 import datetime as dt
 
+import pandas as pd
+
 from prereise.gather.griddata.hifld import const
 from prereise.gather.griddata.hifld.data_access.load import get_eia_form_860
+from prereise.gather.hydrodata.eia.fetch_historical import get_generation
+from prereise.gather.impute import linear
 from prereise.gather.solardata.nsrdb.sam import retrieve_data_individual
 from prereise.gather.winddata.hrrr.calculations import calculate_pout_individual
 from prereise.gather.winddata.hrrr.hrrr import retrieve_data
@@ -99,4 +103,122 @@ def build_wind(wind_plants, download_directory, year):
         end_dt=end_dt,
         directory=download_directory,
     )
+    return profiles
+
+
+def filter_anomalies_impute(series, capacity, rel_min=-1, rel_max=2, max_count=100):
+    """Given a time-series of generation and an assumed capacity, identify anomalous
+    points and replace them by linear imputation (unless there are too many, in which
+    case return a copy of the original.
+
+    :param pandas.Series/numpy.ndarray series: 1-D data to filter and impute (MW).
+    :param int/float capacity: assumed capacity (MW).
+    :param int/float rel_min: lower screening value (relative to ``capacity``).
+    :param int/float rel_max: upper screening value (relative to ``capacity``).
+    :param int max_count: the maximum number of anomalies that can be replaced. If more
+        than this number exist, the series will be returned as is.
+    :return: (*pandas.Series*) -- data, imputed as applicable.
+    :raise ValueError: if series isn't a 1-D object
+    """
+    if len(series.shape) != 1:
+        raise ValueError("series must be of one-dimentional shape")
+    suspected_anomalies = (series > rel_max * capacity) | (series < rel_min * capacity)
+    output = series.copy()
+    if suspected_anomalies.sum() == 0:
+        return output
+    if suspected_anomalies.sum() > max_count:
+        print(f"Too many suspected anomalies for {series.name}, none will be filtered")
+        return output
+    output.loc[suspected_anomalies] = float("nan")
+    return linear(output.to_frame(), inplace=False).squeeze()
+
+
+def parse_eia_to_normalized(hydro_plants, generation, query_regions, year):
+    """Given hydro generation profiles (MW) for a set of balancing authorities, create
+    profiles which are capacity-normalized for a superset of balancing authorities.
+    Profiles are normalized either using the total capacity of the balancing authority's
+    hydro capacity or by peak generation, whichever is greater. Balancing authorities
+    which are missing from the source generation data are populated using a profile
+    aggregated from all available balancing authorities.
+
+    :param pandas.DataFrame hydro_plants: data frame of hydro plant data, including
+        columns 'Balancing Authority Code' and 'Pmax'.
+    :param pandas.DataFrame generation: data frame of hourly generation. Index is
+        timestamps, columns are balancing authority codes, values are total generation.
+    :param set query_regions: superset of balacing authority areas to produce profiles
+        for.
+    :param int/str year: year to use for output profile timestamps.
+    :return: (*pandas.DataFrame*) -- index is hourly timestamps for the given year,
+        columns are the superset balancing authorities, values are normalized
+        generation.
+    """
+    # Filter generation anomalies based on installed capacity
+    ba_groups = hydro_plants.groupby("Balancing Authority Code")
+    ba_capacities = ba_groups["Pmax"].sum()
+
+    # Normalize regional totals by regional capacities (or peak generation)
+    normalized_by_generation = generation.columns[
+        generation.max() > ba_capacities.loc[generation.columns]
+    ]
+    if len(normalized_by_generation) > 0:
+        print("regions normalized by generation profile:")
+        print(
+            generation[normalized_by_generation].max()
+            / ba_capacities.loc[normalized_by_generation]
+        )
+    normalizing_capacity = pd.concat(
+        [ba_capacities.loc[generation.columns], generation.max()],
+        axis=1,
+    ).max(axis=1)
+    normalized_profiles = generation / normalizing_capacity
+
+    # Build shape for 'default' (weighted average of other shapes)
+    normalized_profiles["default"] = (
+        normalized_profiles * ba_capacities.loc[normalized_profiles.columns]
+    ).sum(axis=1) / ba_capacities.loc[normalized_profiles.columns].sum()
+
+    # Build the output dataframe, and populate it
+    profiles = pd.DataFrame(
+        index=pd.date_range(start=f"{year}-01-01-00", end=f"{year}-12-31-23", freq="H"),
+        columns=hydro_plants.index,
+    )
+    for region in query_regions:
+        plant_ids = ba_groups.get_group(region).index
+        if region in normalized_profiles:
+            template = normalized_profiles[region]
+        else:
+            print(region, "uses 'default' hydro profile")
+            template = normalized_profiles["default"]
+        # pandas won't broadcast for us, so we need to construct a 2D object
+        profiles.loc[:, plant_ids] = pd.concat(
+            [template] * len(plant_ids), axis=1
+        ).values
+
+    return profiles
+
+
+def build_hydro(eia_api_key, hydro_plants, year, **hydro_kwargs):
+    """Use plant-level data to build hydro profiles.
+
+    :param str eia_api_key: API key.
+    :param pandas.DataFrame hydro_plants: data frame of hydro generators.
+    :param int/str year: year of data to fetch and build profiles for.
+    :param dict hydro_kwargs: keyword arguments to pass to
+        :func:`prereise.gather.hydrodata.eia.fetch_historical.get_generation`.
+    :return: (*pandas.DataFrame*) -- data frame of normalized power profiles. The index
+        is hourly timestamps for the profile year, the columns are plant IDs, the values
+        are floats.
+    """
+    # Build shapes for each region
+    query_regions = set(hydro_plants["Balancing Authority Code"].unique())
+    hydro_kwargs["year"] = year
+    generation = get_generation(eia_api_key, regions=query_regions, **hydro_kwargs)
+    # Initial screen: any points > 2x capacity or < -1 * capacity
+    ba_capacities = hydro_plants.groupby("Balancing Authority Code")["Pmax"].sum()
+    imputed = generation.apply(
+        lambda x: filter_anomalies_impute(x, capacity=ba_capacities.loc[x.name])
+    )
+    # Normalize
+    profiles = parse_eia_to_normalized(hydro_plants, imputed, query_regions, year)
+
     return profiles

--- a/prereise/gather/hydrodata/eia/fetch_historical.py
+++ b/prereise/gather/hydrodata/eia/fetch_historical.py
@@ -1,0 +1,130 @@
+import re
+
+import pandas as pd
+import requests
+from tqdm import tqdm
+
+from prereise.gather.impute import linear
+
+category_template = (
+    "https://api.eia.gov/category/?api_key={api_key}&category_id={category_id}"
+)
+series_template = "https://api.eia.gov/series/?api_key={api_key}&series_id={series_id}"
+top_level_category_id = 3390101
+
+
+def parse_input_regions(available_regions, requested_regions):
+    """Parse requested regions, allowing either exact string matches or balancing
+    authority abbreviations.
+
+    :param iterable available_regions: set of available regions (str).
+    :param iterable requested_regions: set of request regions (str).
+    :return: (*set*) -- parsed regions.
+    :raises ValueError: if any requested region isn't present in the set available from
+        EIA, or matches multiple available regions.
+    """
+    parsed_regions = set()
+    for r in requested_regions:
+        if r in available_regions:
+            parsed_regions.add(r)
+            continue
+        abbreviation_matches = {a for a in available_regions if f"({r})" in a}
+        if len(abbreviation_matches) == 0:
+            print(f"No hydro data available for region {r}, skipping")
+            continue
+        if len(abbreviation_matches) > 1:
+            raise ValueError(f"Multiple regions found for {r}: {abbreviation_matches}")
+        (single_match,) = abbreviation_matches  # unpack singleton set
+        parsed_regions.add(single_match)
+    return parsed_regions
+
+
+def get_generation(api_key, year, regions=None, acceptable_missing=48, verbose=False):
+    """Fetch hourly generation by balancing authority from EIA, filter to regions with
+    a full year of hydro data for the given year.
+
+    :param str api_key: EIA api key from <https://www.eia.gov/opendata/register.php>.
+    :param int/str year: year of data to return. Any regions with too many missing
+        entries in this year will be dropped (see ``acceptable_missing``).
+    :param iterable regions: subset of regions to fetch & return. If None, all will be
+        returned.
+    :param int acceptable_missing: the maximum allowable number of missing hours of data
+        for each region. If an allowable number of hours are missing, values will be
+        linearly imputed. If more than this number are missing in the given ``year``,
+        the region will be dropped from the output.
+    :param bool verbose: whether or not to report the number of missing hours for each
+        region which gets dropped (based on the ``acceptable_missing`` parameter).
+    :return: (*pandas.DataFrame*) -- index is hourly timestamps in the given year,
+        columns are balancing authority abbreviations, values are total hydro generation
+        (MW).
+    """
+    # This request gives us the available subcategories (regions)
+    regions_metadata = requests.get(
+        category_template.format(api_key=api_key, category_id=top_level_category_id)
+    ).json()
+    region_categories = {
+        c["name"]: c["category_id"]
+        for c in regions_metadata["category"]["childcategories"]
+    }
+    available_regions = region_categories.keys()
+    if regions is None:
+        regions = region_categories.keys()
+    parsed_regions = parse_input_regions(available_regions, regions)
+    parsed_series_data = []
+    skipped_regions = set()
+    for region in tqdm(parsed_regions, total=len(parsed_regions)):
+        # This request gives us the available sub-sub-categories (fuel, timezone)
+        url = category_template.format(
+            api_key=api_key, category_id=region_categories[region]
+        )
+        subcategories_response = requests.get(url).json()
+        # Filter these by their names to hydro, UTC
+        matching_series_set = {
+            series["series_id"]
+            for series in subcategories_response["category"]["childseries"]
+            if "hourly - UTC time" in series["name"] and "hydro" in series["name"]
+        }
+        # Check for existence of UTC hydro data
+        if len(matching_series_set) == 0:
+            skipped_regions.add(region)
+            continue
+        # Extract the only value from a singleton set
+        (series_id,) = matching_series_set
+        # Query just that series
+        series_response = requests.get(
+            series_template.format(api_key=api_key, series_id=series_id)
+        ).json()
+        # Parse the full response to a Series containing just the data
+        series_data = (
+            pd.DataFrame(series_response["series"][0]["data"]).set_index(0).squeeze()
+        )
+        series_data.index = pd.to_datetime(series_data.index)
+        series_data.name = region
+        parsed_series_data.append(series_data)
+    if len(skipped_regions) > 0:
+        print(f"no hydro data found for {sorted(skipped_regions)}")
+    full_data = pd.concat(parsed_series_data, axis=1)
+    # Evaluate the number of missing entries for each region
+    num_missing = full_data.loc[f"{year}-01-01-00":f"{year}-12-31-23"].isna().sum()
+    acceptable_num_missing = num_missing <= acceptable_missing
+    imputed_regions = full_data.columns[
+        (0 < num_missing) & (num_missing <= acceptable_missing)
+    ]
+    missing_entry_regions = full_data.columns[~acceptable_num_missing]
+    full_year_data_regions = full_data.columns[acceptable_num_missing]
+    if len(imputed_regions) > 0:
+        print(f"acceptable missing entries for {sorted(imputed_regions)}, imputing")
+    if len(missing_entry_regions) > 0:
+        print(f"inadequate data for {sorted(missing_entry_regions)} for {year}")
+    if verbose and len(missing_entry_regions) > 0:
+        print(num_missing.loc[missing_entry_regions])
+    # Impute
+    imputed = linear(
+        full_data.loc[f"{year}-01-01-00":f"{year}-12-31-23", full_year_data_regions],
+        inplace=False,
+    )
+    # Rename columns for brevity. 'Longname (ABV)' becomes simply 'ABV'
+    imputed.columns = [
+        re.search(r"\(([A-Z]*[0-9]*)\)", c).group(1) for c in imputed.columns
+    ]
+    return imputed

--- a/prereise/gather/impute.py
+++ b/prereise/gather/impute.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+
+def linear(data, inplace=True):
+    """Given a 2D array, linearly interpolate any missing values column-wise.
+
+    :param numpy.array/pandas.DataFrame data: data to interpolate.
+    :param bool inplace: whether to modify the data inplace or return a modified copy.
+    :return: (*None/pandas.DataFrame*) -- if ``inplace`` is False, data frame with
+        missing entries imputed.
+    """
+    data_impute = data if inplace else data.copy()
+    data_impute[:] = pd.DataFrame(data_impute).interpolate()
+    if not inplace:
+        return data_impute

--- a/prereise/gather/winddata/hrrr/calculations.py
+++ b/prereise/gather/winddata/hrrr/calculations.py
@@ -8,9 +8,9 @@ from powersimdata.utility.distance import ll2uv
 from scipy.spatial import KDTree
 from tqdm import tqdm
 
+from prereise.gather.impute import linear
 from prereise.gather.winddata import const
 from prereise.gather.winddata.hrrr.helpers import formatted_filename
-from prereise.gather.winddata.impute import linear
 from prereise.gather.winddata.power_curves import (
     get_power,
     get_state_power_curves,

--- a/prereise/gather/winddata/impute.py
+++ b/prereise/gather/winddata/impute.py
@@ -137,17 +137,3 @@ def gaussian(data, wind_farm, inplace=True, curve="state"):
 
     if not inplace:
         return data_impute
-
-
-def linear(data, inplace=True):
-    """Given a 2D array, linearly interpolate any missing values column-wise.
-
-    :param numpy.array/pandas.DataFrame data: data to interpolate.
-    :param bool inplace: whether to modify the data inplace or return a modified copy.
-    :return: (*None/pandas.DataFrame*) -- if ``inplace`` is False, data frame with
-        missing entries imputed.
-    """
-    data_impute = data if inplace else data.copy()
-    data_impute[:] = pd.DataFrame(data_impute).interpolate()
-    if not inplace:
-        return data_impute


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Generate hydro profiles at the same time as we build the HIFLD grid, so that we can leverage the plant-specific attributes of each hydro plant to generate better profiles (partial fulfillment of #227). We do this based on hydro data by BA, retried from the EIA at https://www.eia.gov/opendata/qb.php?category=3390101 (via their API).

### What the code is doing
- We add a new module `prereise.gather.hydrodata.eia.fetch_historical`, with a user-facing function `get_generation` that retrieves historical generation by BA for a set of regions, over a selected year.
- We add a new function `build_hydro` which uses these per-BA totals to come up with normalized per-BA profiles, and uses these to build a per-plant hydro profile dataframe.
- We call `build_hydro` from within the orchestration function.

### Testing
- `get_generation` has been thoroughly tested and works as expected.
- `build_hydro` works, although the values that are returned are somewhat unexpected (see https://github.com/Breakthrough-Energy/PreREISE/pull/261#issuecomment-1023454400)
- the broader integration with `create_csvs` works, although because of the data that `build_hydro` returns, we need to clip the profiles to the range [0, 1] before running simulations.

### Usage Examples
```python
import pandas as pd
from prereise.gather.griddata.hifld.data_process.profiles import build_hydro, floatify
from prereise.gather.hydrodata.eia.fetch_historical import get_generation

eia_api_key = YOUR_EIA_API_KEY
hydro_plants = pd.read_csv(PATH_TO_FORM_860_3).query("`Energy Source 1` == 'WAT'")
hydro_plants = hydro_plants.merge(pd.read_csv(PATH_TO_FORM_860_2), on="Plant Code")
hydro_plants["Pmax"] = (
    hydro_plants[['Summer Capacity (MW)', 'Winter Capacity (MW)']]
    .max(axis=1)
    .map(floatify)
)
hydro_plants = hydro_plants.loc[~hydro_plants["Balancing Authority Code"].isnull()]
# Build normalized profiles for each plant
df = build_hydro(eia_api_key, hydro_plants, 2021)
# Get the raw generation numbers for each BA
df2 = get_generation(eia_api_key, 2021, regions=hydro_plants["Balancing Authority Code"].unique())
```

### Time estimate
1 hour. This is a draft PR since it depends on #256, and there are still conversations about how we may want to modify the hydro profile generation process, but the code that retrieves and parses the EIA data has been well-tested and should be pretty close to its final state.