### PR TITLE
fix: add filtering of same-substation lines after consolidation

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -532,7 +532,6 @@ line_interconnect_assumptions = {
         135527,
         141367,
         300170,
-        301858,
         303906,
         305887,
         306332,
@@ -542,7 +541,7 @@ line_interconnect_assumptions = {
         311520,
     },
     "Western": {123525, 141873},
-    "ERCOT": {305330, 309428, 310121},
+    "ERCOT": {305330},
 }
 
 b2b_ratings = {  # MW

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -140,6 +140,15 @@ def map_lines_to_substations_using_coords(
         new_lines[e_sub] = substations.loc[primary_sub.values, "NAME"].values
         new_lines[f"{e_sub}_ID"] = primary_sub.values
 
+    # Remove lines which ended up assigned to the same substation after consolidation
+    if drop_zero_distance_line:
+        idx = new_lines["SUB_1_ID"].compare(new_lines["SUB_2_ID"]).index
+        print(
+            f"dropping {new_lines.shape[0] - len(idx)} lines having same endpoints "
+            "after substation consolidation"
+        )
+        new_lines = new_lines.loc[idx]
+
     return new_lines, new_substations
 
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Avoid producing a grid which has branches with the same start and end bus, by filtering any lines that end up with the same substation after the main `map_lines_to_substations_using_coords` logic. I _think_ what's going on is: we're already filtering lines whose endpoints are the same after the specified rounding, but endpoints with different endpoint coordinates can still end up mapped to the same substation (or group of substations). I may be misinterpreting what's going on though.

### What the code is doing
Following the example from before, we use `pandas.Series.compare` to find indices where the values don't match, and filter to just those values.

With the filtering in place, we also need to amend `const.substation_interconnect_assumptions` to remove these lines which had been manually specified as one interconnection or another.

### Testing
Tested manually, using the test introduced in https://github.com/Breakthrough-Energy/PowerSimData/pull/578. Before: the test fails. After: the test passes. During grid building, we see `dropping 3185 lines having same endpoints after substation consolidation`, after the previous filtering step: `dropping 4473 lines having same endpoints coordinates after rounding`.

### Time estimate
5 minutes to understand the change itself, longer if you want to head-scratch about the root cause that the change fixes.
