### PR TITLE
feat: translate per-length impedance values to whole-line parameters

### DIFF
--- a/prereise/gather/griddata/transmission/geometry.py
+++ b/prereise/gather/griddata/transmission/geometry.py
@@ -280,11 +280,11 @@ class Line(DataclassWithValidation):
                 setattr(self, attr, float(getattr(self, attr)))
         self.validate_input_types()  # defined in DataclassWithValidation
         # Calculate second-order electrical parameters which depend on frequency
-        self.omega = 2 * pi * self.freq
+        omega = 2 * pi * self.freq
         self.series_impedance_per_km = (
-            self.tower.resistance + 1j * self.tower.inductance * self.omega
+            self.tower.resistance + 1j * self.tower.inductance * omega
         )
-        self.shunt_admittance_per_km = 1j * self.tower.capacitance * self.omega
+        self.shunt_admittance_per_km = 1j * self.tower.capacitance * omega
         self.surge_impedance = cmath.sqrt(
             self.series_impedance_per_km / self.shunt_admittance_per_km
         )

--- a/prereise/gather/griddata/transmission/geometry.py
+++ b/prereise/gather/griddata/transmission/geometry.py
@@ -1,3 +1,4 @@
+import cmath
 from dataclasses import dataclass, field
 from itertools import combinations
 from math import exp, log, pi, sqrt
@@ -32,7 +33,7 @@ class Conductor(DataclassWithValidation):
     resistance_per_km: float = None
     gmr: float = None
     area: float = None
-    permeability: float = field(init=False)
+    permeability: float = field(init=False, default=None)
 
     def __post_init__(self):
         # Validate inputs
@@ -248,6 +249,58 @@ class Tower(DataclassWithValidation):
             )
         )
         return capacitance_per_km
+
+
+@dataclass
+class Line(DataclassWithValidation):
+    """Given a Tower design, line voltage, and length, calculate whole-line impedances
+    and rating.
+
+    :param Tower tower: tower parameters (containing per-kilometer impedances).
+    :param int/float length: line length (kilometers).
+    :param int/float voltage: line voltage (kilovolts).
+    :param int/float freq: the system nominal frequency (Hz).
+    """
+
+    tower: Tower
+    length: float
+    voltage: float
+    freq: float = 60.0
+    series_impedance_per_km: complex = field(init=False)
+    shunt_admittance_per_km: complex = field(init=False)
+    propogation_constant_per_km: complex = field(init=False)
+    surge_impedance: complex = field(init=False)
+    series_impedance: complex = field(init=False)
+    shunt_admittance: complex = field(init=False)
+
+    def __post_init__(self):
+        # Convert integers to floats as necessary
+        for attr in ("freq", "length", "voltage"):
+            if isinstance(getattr(self, attr), int):
+                setattr(self, attr, float(getattr(self, attr)))
+        self.validate_input_types()  # defined in DataclassWithValidation
+        # Calculate second-order electrical parameters which depend on frequency
+        self.omega = 2 * pi * self.freq
+        self.series_impedance_per_km = (
+            self.tower.resistance + 1j * self.tower.inductance * self.omega
+        )
+        self.shunt_admittance_per_km = 1j * self.tower.capacitance * self.omega
+        self.surge_impedance = cmath.sqrt(
+            self.series_impedance_per_km / self.shunt_admittance_per_km
+        )
+        self.propogation_constant_per_km = cmath.sqrt(
+            self.series_impedance_per_km * self.shunt_admittance_per_km
+        )
+        self.surge_impedance_loading = self.voltage**2 / abs(self.surge_impedance)
+        # Use the long-line transmission model to calculate lumped-element parameters
+        self.series_impedance = (self.series_impedance_per_km * self.length) * (
+            cmath.sinh(self.propogation_constant_per_km * self.length)
+            / (self.propogation_constant_per_km * self.length)
+        )
+        self.shunt_admittance = (self.shunt_admittance_per_km * self.length) * (
+            cmath.tanh(self.propogation_constant_per_km * self.length / 2)
+            / (self.propogation_constant_per_km * self.length / 2)
+        )
 
 
 def _euclidian(a, b):

--- a/prereise/gather/griddata/transmission/geometry.py
+++ b/prereise/gather/griddata/transmission/geometry.py
@@ -33,7 +33,7 @@ class Conductor(DataclassWithValidation):
     resistance_per_km: float = None
     gmr: float = None
     area: float = None
-    permeability: float = field(init=False, default=None)
+    permeability: float = None
 
     def __post_init__(self):
         # Validate inputs


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add logic to translate per-distance impedance values to lumped-element values suitable for power system modeling, and to calculate surge impedance loading.

### What the code is doing
A new `Line` class is added, which is a combination of a `Tower` object (which includes all conductor/bundle information) a `length`, a `voltage`, and a `freq` (frequency). With these, impedances which depend on the system frequency are calculated, and the voltage and surge impedance are used to calculate the surge impedance loading. Per-kilometer shunt admittance and series impedance are used along with the `length` parameter to calculate equivalent π-model lumped element parameters using the long-line distributed impedance model. The differences between the long-line model and the short- or medium-line model are insignificant for shorter lines, but important for longer ones, and the computational burden to calculate all of them the more complicated way is low compared to everything else the grid-building code does.

There are also a few minor changes to clean up small lingering things from #262, which impact prints but not core functionality.

### Testing
A new unit test is added which tests this functionality against an example from a power systems textbook.

### Usage Example/Visuals
The new unit test shows how lowest-level parameters are combined to calculate whole-line impedances. This example is single-circuit single-conductor, but other tests demonstrate how multi-circuit and/or bundled conductors can be specified.

### Time estimate
15 minutes to understand the code, longer if you want to crack open your own power system textbook and brush up on the logic or try a few examples.
