### PR TITLE
feat: use transmission line physical parameters to calculate impedances and ratings for HIFLD grid

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -594,6 +594,10 @@ line_interconnect_assumptions = {
     "ERCOT": {305330},
 }
 
+line_voltage_assumptions = {
+    128842: 230,
+}
+
 line_design_assumptions = {
     # branch index: (voltage, circuits, bundle count)
     101536: (161, 2, 4),  # TVA Cumberland (between substations)

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -125,43 +125,6 @@ volt_class_defaults = {
     "500": 500,
 }
 
-line_reactance_per_mile = {  # per-unit
-    69: 0.0096,
-    100: 0.0063,
-    115: 0.0039,
-    138: 0.0026,
-    161: 0.0021,
-    230: 0.0011,
-    345: 0.0005,
-    500: 0.0002,
-    765: 0.0001,
-}
-line_rating_short = {  # MVA
-    69: 86,
-    100: 181,
-    115: 239,
-    138: 382,
-    161: 446,
-    230: 797,
-    345: 1793,
-    500: 2598,
-    765: 5300,
-}
-line_rating_short_threshold = 50  # miles
-line_rating_surge_impedance_loading = {  # MVA
-    69: 13,
-    100: 30,
-    115: 35,
-    138: 50,
-    161: 69,
-    230: 140,
-    345: 375,
-    500: 1000,
-    765: 2250,
-}
-line_rating_surge_impedance_coefficient = 43.261
-line_rating_surge_impedance_exponent = -0.6678
-
 transformer_reactance = {  # per-unit
     (69, 115): 0.14242,
     (69, 138): 0.10895,

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -1,3 +1,5 @@
+s_base = 100  # MVA
+
 mile_to_meter = 1609.34
 meter_to_mile = 1.0 / mile_to_meter
 

--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -594,6 +594,43 @@ line_interconnect_assumptions = {
     "ERCOT": {305330},
 }
 
+line_design_assumptions = {
+    # branch index: (voltage, circuits, bundle count)
+    101536: (161, 2, 4),  # TVA Cumberland (between substations)
+    103726: (161, 2, 4),  # TVA Cumberland (plant to substation)
+    110220: (115, 1, 2),  # Riverside Generating Station
+    112166: (230, 1, 2),  # Waterford 3 Nuclear Generating Station
+    116493: (230, 1, 2),  # Herbert A. Wagner Generating Station
+    132671: (230, 1, 3),  # Florida Power & Light St. Lucie
+    130105: (161, 1, 3),  # TVA Cumberland (downstream)
+    132804: (230, 1, 2),  # Waterford 3 Nuclear Generating Station
+    139216: (230, 4, 3),  # Catawba Nuclear Station
+    140651: (230, 1, 3),  # Florida Power & Light St. Lucie
+    147054: (115, 1, 2),  # RE Ginna Nuclear Power Plant
+    158263: (100, 1, 4),  # G. G. Allen Steam Station
+    160723: (230, 1, 3),  # Florida Power & Light St. Lucie
+    203381: (230, 1, 2),  # Midpoint to Boise Bench
+    203382: (230, 1, 2),  # Midpoint to Boise Bench
+    203383: (230, 1, 2),  # Midpoint to Boise Bench
+    300029: (69, 2, 1),  # Ormat Brawley geothermal
+    301320: (138, 2, 2),  # Collin/Frisco substation connection
+    301847: (115, 1, 2),  # Coso Power Station
+    303557: (138, 2, 2),  # West Levee substations connection (Dallas)
+    304908: (69, 2, 1),  # Heber geothermal
+    305018: (138, 2, 2),  # TH Wharton Generating Station
+    305464: (230, 2, 2),  # The Geysers
+    305990: (100, 2, 1),  # southeast Salton Sea geothermal plants (several)
+    306949: (230, 2, 2),  # The Geysers
+    307569: (230, 2, 2),  # The Geysers
+    308434: (230, 2, 2),  # The Geysers
+    309268: (69, 2, 1),  # Ormat Brawley geothermal
+    309441: (69, 2, 2),  # substation connection near Lake Creek Reservoir, outside Waco
+    309966: (138, 2, 2),  # Garfield to Pilot Knob (south of Austin)
+    312241: (100, 2, 1),  # southeast Salton Sea geothermal plants (several)
+    313473: (69, 2, 2),  # Holtville geothermal?
+    313474: (69, 2, 2),  # Holtville geothermal?
+}
+
 b2b_ratings = {  # MW
     "BLACKWATER TIE": 200,  # a.k.a. 'Clovis'/'Roosevelt County' (Eastern/Western)
     "EDDY AC-DC-AC TIE": 200,  # a.k.a. 'Artesia' (Eastern/Western)

--- a/prereise/gather/griddata/hifld/data/line_designs.csv
+++ b/prereise/gather/griddata/hifld/data/line_designs.csv
@@ -1,0 +1,23 @@
+voltage,circuits,bundle_count,conductor,spacing,a0x,a0y,b0x,b0y,c0x,c0y,a1x,a1y,b1x,b1y,c1x,c1y,a2x,a2y,b2x,b2y,c2x,c2y,a3x,a3y,b3x,b3y,c3x,c3y,notes
+69,1,1,Osprey,,-2,16.5,2,15,-2,13.5,,,,,,,,,,,,,,,,,,,single-pole design
+69,2,1,Osprey,,-2,16.5,-2,15,-2,13.5,2,13.5,2,15,2,16.5,,,,,,,,,,,,,single-pole double-circuit
+69,2,2,Osprey,0.5,-2,16.5,-2,15,-2,13.5,2,13.5,2,15,2,16.5,,,,,,,,,,,,,single-pole double-circuit
+100,1,1,Drake,,-2,19,2,17,-2,15,,,,,,,,,,,,,,,,,,,single-pole design
+100,2,1,Drake,,-2,19,-2,17,-2,15,2,15,2,17,2,19,,,,,,,,,,,,,single-pole double-circuit
+100,1,4,Drake,0.5,-7,15,0,15,7,15,,,,,,,,,,,,,,,,,,,H-frame design
+115,1,1,Drake,,-2,19,2,17,-2,15,,,,,,,,,,,,,,,,,,,single-pole design
+115,1,2,Drake,0.5,-4,15,0,15,4,15,,,,,,,,,,,,,,,,,,,H-frame design
+138,1,1,Ortolan,,-3,22.5,3,20,-3,17.5,,,,,,,,,,,,,,,,,,,single-pole design
+138,2,2,Ortolan,0.5,-7.5,15,-4.5,15,-1.5,15,1.5,15,4.5,15,7.5,15,,,,,,,,,,,,,two parallel H-frames
+161,1,1,Bluejay,,-5,15,0,15,5,15,,,,,,,,,,,,,,,,,,,H-frame design
+161,1,3,Bluejay,0.5,-6,15,0,15,6,15,,,,,,,,,,,,,,,,,,,lattice
+161,2,4,Bluejay,0.5,-5,15,-5,17,-5,19,5,19,5,17,5,15,,,,,,,,,,,,,Two parallel single-poles
+230,1,1,Falcon,,-7,20,0,20,7,20,,,,,,,,,,,,,,,,,,,H-frame design
+230,1,2,Drake,0.5,-7,20,0,20,7,20,,,,,,,,,,,,,,,,,,,H-frame design
+230,1,3,Drake,0.5,-7,20,0,20,7,20,,,,,,,,,,,,,,,,,,,H-frame design
+230,2,2,Drake,0.5,-3,19,-3,17,-3,15,3,15,3,17,3,19,,,,,,,,,,,,,Double-circuit lattice
+230,4,3,Drake,0.5,-7,20,0,20,7,20,18,20,25,20,32,20,43,20,50,20,57,20,68,20,75,20,82,20,Four parallel H-frames
+345,1,2,Falcon,0.5,-8,25,0,25,8,25,,,,,,,,,,,,,,,,,,,H-frame design
+500,1,3,Rail,0.5,-10,30,0,30,10,30,,,,,,,,,,,,,,,,,,,lattice
+500,2,3,Drake,0.5,-5,40,-8,30,-5,20,5,20,8,30,5,40,,,,,,,,,,,,,lattice
+765,1,4,Martin,0.5,-15,40,0,40,15,40,,,,,,,,,,,,,,,,,,,H-frame design

--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -7,6 +7,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from prereise.gather.griddata.hifld import const
 from prereise.gather.griddata.hifld.data_process.transmission import (
     add_impedance_and_rating,
+    add_substation_info_to_buses,
     assign_buses_to_lines,
     augment_line_voltages,
     create_buses,
@@ -35,6 +36,32 @@ def test_add_impedance_and_rating():
     expected_modified_branch = pd.concat([branch, expected_new_columns], axis=1)
     add_impedance_and_rating(branch, bus_voltages=None)
     assert_frame_equal(branch, expected_modified_branch)
+
+
+def test_add_substation_info_to_buses():
+    bus = pd.DataFrame({"sub_id": [0, 0, 1, 2]})
+    substations = pd.DataFrame(
+        {
+            "interconnect": ["Eastern", "Western", "Western", "Western", "ERCOT"],
+            "STATE": ["MT", "MT", "CA", "CA", "TX"],
+        }
+    )
+    zones = pd.DataFrame(
+        {
+            "state": ["Montana", "Montana", "California", "Texas"],
+            "interconnect": ["Western", "Eastern", "Western", "ERCOT"],
+            "zone_id": ["MT Western", "MT Eastern", "California", "TX ERCOT"],
+        }
+    )
+    expected_new_columns = pd.DataFrame(
+        {
+            "interconnect": ["Eastern", "Eastern", "Western", "Western"],
+            "zone_id": ["MT Eastern", "MT Eastern", "MT Western", "California"],
+        }
+    )
+    expected_bus = pd.concat([bus, expected_new_columns], axis=1)
+    add_substation_info_to_buses(bus, substations, zones)
+    assert_frame_equal(bus, expected_bus)
 
 
 def test_augment_line_voltages_volt_class():

--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -6,6 +6,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 
 from prereise.gather.griddata.hifld import const
 from prereise.gather.griddata.hifld.data_process.transmission import (
+    add_b2bs_to_dc_lines,
     add_impedance_and_rating,
     add_substation_info_to_buses,
     assign_buses_to_lines,
@@ -17,6 +18,22 @@ from prereise.gather.griddata.hifld.data_process.transmission import (
     filter_islands_and_connect_with_mst,
     map_lines_to_substations_using_coords,
 )
+
+
+def test_add_b2bs_to_dc_lines():
+    dc_lines = pd.DataFrame(
+        {"SUB_1_ID": [1, 2], "SUB_2_ID": [3, 4], "Pmax": [5, 6]},
+        index=[200, 201],
+    )
+    substations = pd.DataFrame(
+        {"NAME": ["Wango_West", "Jango", "Wango_East", "Tango_South", "Tango_North"]}
+    )
+    b2b_ratings = {"Wango": 100, "Tango": 200}
+    expected_new_rows = pd.DataFrame(
+        {"SUB_1_ID": [0, 3], "SUB_2_ID": [2, 4], "Pmax": [100, 200]}, index=[300, 301]
+    )
+    add_b2bs_to_dc_lines(dc_lines, substations, b2b_ratings)
+    assert_frame_equal(dc_lines.iloc[2:], expected_new_rows)
 
 
 def test_add_impedance_and_rating():

--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -6,6 +6,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 
 from prereise.gather.griddata.hifld import const
 from prereise.gather.griddata.hifld.data_process.transmission import (
+    add_impedance_and_rating,
     assign_buses_to_lines,
     augment_line_voltages,
     create_buses,
@@ -14,6 +15,25 @@ from prereise.gather.griddata.hifld.data_process.transmission import (
     estimate_branch_rating,
     map_lines_to_substations_using_coords,
 )
+
+
+def test_add_impedance_and_rating():
+    branch = pd.DataFrame(
+        {
+            "VOLTAGE": [69, 75, 75, 138],
+            "length": [10, 20, 100, 50],
+            "type": ["Line"] * 4,
+        }
+    )
+    expected_new_columns = pd.DataFrame(
+        {
+            "x": [0.0963365, 0.163066, 0.813330, 0.122386],
+            "rateA": [85.4507, 92.8812, 42.5257, 227.1693],
+        }
+    )
+    expected_modified_branch = pd.concat([branch, expected_new_columns], axis=1)
+    add_impedance_and_rating(branch, bus_voltages=None)
+    assert_frame_equal(branch, expected_modified_branch)
 
 
 def test_augment_line_voltages_volt_class():

--- a/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_transmission.py
@@ -17,6 +17,7 @@ from prereise.gather.griddata.hifld.data_process.transmission import (
     estimate_branch_rating,
     filter_islands_and_connect_with_mst,
     map_lines_to_substations_using_coords,
+    split_lines_to_ac_and_dc,
 )
 
 
@@ -341,3 +342,14 @@ def test_assign_buses_to_lines():
     assert ac_lines["to_bus_id"].equals(pd.Series([310, 311, 410]))
     assert dc_lines["from_bus_id"].equals(pd.Series([311]))
     assert dc_lines["to_bus_id"].equals(pd.Series([400]))
+
+
+def test_split_lines_to_ac_and_dc():
+    lines = pd.DataFrame(
+        {"TYPE": ["DC; OVERHEAD", "DC; UNDERGROUND", "AC", "AC", "unknown", "unknown"]},
+        index=[101, 102, 103, 104, 105, 106],
+    )
+    dc_override_indices = {105}
+    ac_lines, dc_lines = split_lines_to_ac_and_dc(lines, dc_override_indices)
+    assert ac_lines.index.tolist() == [103, 104, 106]
+    assert dc_lines.index.tolist() == [101, 102, 105]

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -403,7 +403,11 @@ def filter_islands_and_connect_with_mst(
 
 
 def augment_line_voltages(
-    lines, substations, volt_class_defaults=None, state_threshold_100_161=0.95
+    lines,
+    substations,
+    volt_class_defaults=None,
+    voltage_assumptions=None,
+    state_threshold_100_161=0.95,
 ):
     """Fill in voltages for lines with missing voltages, using a series of heuristics.
     The ``lines`` dataframe will be modified in-place.
@@ -412,6 +416,8 @@ def augment_line_voltages(
     :param pandas.DataFrame substations: data frame of substations.
     :param dict/pandas.Series volt_class_defaults: mapping of volt classes to default
         replacement voltage values. If None, internally-defined defaults will be used.
+    :param dict/pandas.Series voltage_assumptions: mapping of branches to voltages.
+        If None, internally-defined defaults will be used.
     :param int/float state_threshold_100_161: fraction of lines in the 100-161 kV range
         which must be the same voltage for the most common voltage to be applied to
         missing voltage lines in this state.
@@ -455,7 +461,11 @@ def augment_line_voltages(
     # Interpret input parameters
     if volt_class_defaults is None:
         volt_class_defaults = const.volt_class_defaults
+    if voltage_assumptions is None:
+        voltage_assumptions = const.line_voltage_assumptions
 
+    # Set voltages based on per-branch information
+    lines["VOLTAGE"].update(voltage_assumptions)
     # Set voltages based on voltage class defaults
     null_voltages = lines.loc[lines.VOLTAGE.isna()]
     replacement_voltages = null_voltages.VOLT_CLASS.map(volt_class_defaults)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
To build branch ratings and impedances for the HIFLD grid, use assumptions which start with the physical parameters of typical line designs (with non-typical overrides as necessary), rather than relying on processed averages from the TAMU grid.

### What the code is doing
- We add a table of 'typical' tower/conductor designs (`line_designs.csv`). Within `transmission.py`, the default choice for a given voltage level is the single-circuit design with the minimum number of conductors per bundle.
- Within `const.py`:
  - we add the system power base that will be used to calculate per-unit values (`s_base`).
  - ~we make a change to the impedance of 161/500 kV transformers. The existing value produces severe transmission infeasibilities, while the new value fixes them (and is consistent with examination of real world data).~ **EDIT**: removed for now in favor of more extensive transformer re-working within #286.
  - we add a new mapping of lines to voltage (`line_voltage_assumptions`), to be used to override the algorithms within `transmission.py` when problems are encountered.
  - we add a set of assumptions about lines which should be built using the non-default line designs.
- Within `transmission.py`:
  - We apply the line voltage assumptions from `const.py` before performing the neighbor search algorithm to assign voltage to unknown-voltage lines.
  - We add a new function `add_impedance_and_rating` which builds `Tower` objects for each of the designs in `line_designs.csv`, and associates each transmission line in the HIFLD dataset with one of these designs (using either the default or the overrides in `const.py`) before passing this augmented dataframe (original data plus Tower designs) to the existing lower-level `estimate_branch_impedance` and `estimate_branch_rating` functions.
  - We modify the `estimate_branch_impedance` and `estimate_branch_rating` functions to use the `Tower` objects plus the line lengths to calculate the appropriate values for transmission lines (transformer logic is unchanged).
- **EDIT**: within `test_transmission.py`: several new tests aimed at improving the overall test coverage of the `transmission` module.

### Testing
Tested manually to build the HIFLD grid. Preliminary tests show the built grid having much less transmission violation energy and many fewer lines violating, compared to when the grid is built using the assumed values from the TAMU data. Full results to be added later.

~Unit tests still need to be updated.~ EDIT: done.

### Usage Example/Visuals
All code changes will be used by calling the `build_transmission` function (either directly or via `create_csvs` or `create_grid` in the `orchestration` module).

### Time estimate
30 minutes to an hour, provided they already have a good understanding of the line parameter calculation logic, or are willing to trust the previous reviews of that code (#272). ~This branch depends on #272, so is a draft for now.~
