### PR TITLE
ci: run tests on all PRs, not just into develop

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,6 @@ name: Lint
 on: 
   push:
   pull_request:
-    branches:
-      - develop
 
 jobs:
   formatting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Pytest
 on: 
   push:
   pull_request:
-    branches:
-      - develop
 
 jobs:
   test:


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Run tests and linting on all PRs, not just ones into develop.

### What the code is doing
We remove the filter that only PRs into develop get tests and linting.

### Testing
Not tested.

### Time estimate
2 minutes.
