### PR TITLE
feat: add local transmission capacity analysis function

### DIFF
--- a/prereise/gather/griddata/hifld/data_process/helpers.py
+++ b/prereise/gather/griddata/hifld/data_process/helpers.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from prereise.gather.griddata.hifld import const
 
 
@@ -19,3 +21,33 @@ def map_state_and_county_to_interconnect(state_abv, county):
                 return region
         return const.state_county_splits[state_upper]["default"]
     raise ValueError(f"Got an unexpected state: {state_abv}")
+
+
+def distribute_demand_from_zones_to_buses(zone_demand, bus):
+    """Decomposes zone demand to bus demand based on bus 'Pd' column.
+    :param pandas.DataFrame zone_demand: demand by zone. Index is timestamp, columns are
+        zone IDs, values are zone demand (MW).
+    :param pandas.DataFrame bus: table of bus data, containing at least 'zone_id' and
+        'Pd' columns.
+    :return: (*pandas.DataFrame*) -- data frame of demand. Index is timestamp, columns
+        are bus IDs, values are bus demand (MW).
+    :raises ValueError: if the columns of ``zone_demand`` don't match the set of zone
+        IDs within the 'zone_id' column of ``bus``.
+    """
+    if set(bus["zone_id"].unique()) != set(zone_demand.columns):
+        raise ValueError("zones don't match between zone_demand and bus dataframes")
+    grouped_buses = bus.groupby("zone_id")
+    bus_zone_pd = grouped_buses["Pd"].transform("sum")
+    bus_zone_share = pd.concat(
+        [pd.Series(bus["Pd"] / bus_zone_pd, name="zone_share"), bus["zone_id"]], axis=1
+    )
+    zone_bus_shares = bus_zone_share.pivot_table(
+        index="bus_id",
+        columns="zone_id",
+        values="zone_share",
+        dropna=False,
+        fill_value=0,
+    )
+    bus_demand = zone_demand.dot(zone_bus_shares.T)
+
+    return bus_demand

--- a/prereise/gather/griddata/hifld/data_process/tests/test_topology.py
+++ b/prereise/gather/griddata/hifld/data_process/tests/test_topology.py
@@ -326,4 +326,7 @@ def test_identify_bottlenecks():
     }
     for key, result in results_to_check.items():
         for subkey, subresult in result.items():
-            assert bottlenecks["all"][key][subkey] == pytest.approx(result[subkey])
+            if subkey == "descendants":
+                assert bottlenecks["all"][key][subkey] == result[subkey]
+            else:
+                assert bottlenecks["all"][key][subkey] == pytest.approx(result[subkey])

--- a/prereise/gather/griddata/hifld/data_process/topology.py
+++ b/prereise/gather/griddata/hifld/data_process/topology.py
@@ -396,6 +396,7 @@ def identify_bottlenecks(branch, demand, root=None):
         - "constrained": a dictionary, keys and values are idenical to the 'all'
             dictionary except that only entries where demand is greater than capacity
             are contained.
+        - "root": the root node.
     """
     # Build transmission graph
     graph = nx.convert_matrix.from_pandas_edgelist(
@@ -424,4 +425,4 @@ def identify_bottlenecks(branch, demand, root=None):
     constrained_pairs = {
         k: v for k, v in descendant_pairs.items() if v["demand"] > v["capacity"]
     }
-    return {"all": descendant_pairs, "constrained": constrained_pairs}
+    return {"all": descendant_pairs, "constrained": constrained_pairs, "root": root}

--- a/prereise/gather/griddata/hifld/data_process/topology.py
+++ b/prereise/gather/griddata/hifld/data_process/topology.py
@@ -405,8 +405,13 @@ def identify_bottlenecks(branch, demand, root=None):
         - "root": the root node.
     """
     # Build transmission graph
+    sorted_buses = branch[["from_bus_id", "to_bus_id"]].apply(sorted, axis=1).map(tuple)
+    aggregated_capacity = branch.groupby(sorted_buses)["capacity"].sum()
+    aggregated_branch = pd.DataFrame(
+        aggregated_capacity.index.tolist(), columns=["bus1", "bus2"]
+    ).assign(capacity=aggregated_capacity.tolist())
     graph = nx.convert_matrix.from_pandas_edgelist(
-        branch, "from_bus_id", "to_bus_id", ["capacity"]
+        aggregated_branch, "bus1", "bus2", ["capacity"]
     )
     nx.set_node_attributes(graph, {k: {"demand": v} for k, v in demand.items()})
     # Build block-cut graph of biconnected components

--- a/prereise/gather/griddata/hifld/data_process/topology.py
+++ b/prereise/gather/griddata/hifld/data_process/topology.py
@@ -367,7 +367,10 @@ def find_descendants(graph, bctree, parent, grandparent, result=None):
                 graph[child][n]["capacity"] for n in graph[child] if n in parent
             )
             result[(parent, child)]["demand"] = child_descendants["demand"]
-            result[parent]["descendants"].add(child)
+            # Avoid double-counting demand from the articulation point
+            result[parent]["demand"] += (
+                result[(parent, child)]["demand"] - graph.nodes[child]["demand"]
+            )
         else:
             # parent is an articulation point, child is a block
             # downstream branches are connected to parent and within child
@@ -378,7 +381,7 @@ def find_descendants(graph, bctree, parent, grandparent, result=None):
             result[(parent, child)]["demand"] = (
                 child_descendants["demand"] - graph.nodes[parent]["demand"]
             )
-        result[parent]["demand"] += result[(parent, child)]["demand"]
+            result[parent]["demand"] += result[(parent, child)]["demand"]
 
     return result[parent]
 

--- a/prereise/gather/griddata/hifld/data_process/topology.py
+++ b/prereise/gather/griddata/hifld/data_process/topology.py
@@ -315,3 +315,113 @@ def add_interconnects_by_connected_components(
     for i, name in enumerate(interconnect_size_rank):
         substations.loc[sorted_interconnects[i], "interconnect"] = name
     substations.drop(seams_substations, inplace=True)
+
+
+def find_descendants(graph, bctree, parent, grandparent, result=None):
+    """Given a graph and its block-cut tree representation, aggregate demand from leaves
+    towards root and identify capacity bottlenecks along the way.
+
+    :param networkx.Graph graph: original graph, where nodes have at least a 'demand'
+        attribute and edges have at least a 'capacity' attribute.
+    :param networkx.Graph bctree: block-cut tree representation of ``graph``, where
+        articulation point IDs are their original node ID and block ID are a frozenset
+        of the nodes within the block (including articulation points).
+    :param int/frozenset parent: a node ID within ``bctree`` to aggregate 'downstream'
+        demand for and to evaluate capacity constraints towards.
+    :param int/frozenset grandparent: a node ID within ``bctree`` which is directly
+        'upstream' of ``parent``, used to identify 'downstream' directions. If None is
+        passed, then ``parent`` is considered to be the 'root' node, i.e. all directions
+        are 'downstream'.
+    :param dict result: a dictionary to be used to store results. If None is passed, one
+        will be created.
+    :return: (*dict*) -- a dictionary of information for the ``parent`` node. Note: this
+        dictionary is the value of the ``parent`` key within the higher-level ``result``
+        dictionary.
+    """
+    if result is None:
+        result = {}
+    result[parent] = {"descendants": set(), "demand": 0}
+    children = set(bctree[parent]) - {grandparent}
+    if isinstance(parent, int):
+        # parent is an articulation point, children are blocks
+        result[parent]["descendants"] |= set().union(*children) - {parent}
+        result[parent]["demand"] += graph.nodes[parent]["demand"]
+    else:
+        # parent is a block, children are articulation points
+        result[parent]["descendants"] |= children
+        result[parent]["demand"] += sum(graph.nodes[p]["demand"] for p in parent)
+    for child in children:
+        # We need to find all descendants of the child to be able sum their demands
+        child_descendants = find_descendants(graph, bctree, child, parent, result)
+        result[(parent, child)] = {
+            "descendants": child_descendants["descendants"] - {parent},
+        }
+        result[parent]["descendants"] |= child_descendants["descendants"]
+        if isinstance(child, int):
+            # parent is a block, child is an articulation point
+            # downstream branches are connected to child and within parent
+            result[(parent, child)]["capacity"] = sum(
+                graph[child][n]["capacity"] for n in graph[child] if n in parent
+            )
+            result[(parent, child)]["demand"] = child_descendants["demand"]
+            result[parent]["descendants"].add(child)
+        else:
+            # parent is an articulation point, child is a block
+            # downstream branches are connected to parent and within child
+            result[(parent, child)]["capacity"] = sum(
+                graph[parent][n]["capacity"] for n in graph[parent] if n in child
+            )
+            # We don't want to include the articulation point's demand
+            result[(parent, child)]["demand"] = (
+                child_descendants["demand"] - graph.nodes[parent]["demand"]
+            )
+        result[parent]["demand"] += result[(parent, child)]["demand"]
+
+    return result[parent]
+
+
+def identify_bottlenecks(branch, demand, root=None):
+    """Given a table of branch connectivity and capacities, and bus demands, identify
+    bottlenecks 'downstream' of the largest connected component
+
+    :param pandas.DataFrame branch: branch info, containing at least: 'from_bus_id',
+        'to_bus_id', and 'capacity' columns.
+    :param dict/pandas.Series demand: mapping of bus IDs to demand.
+    :param int/frozenset root: node to use as the root of the constructed BC tree. If
+        None, the largest connected component will be chosen.
+    :return: (*dict*) -- dictionary with keys:
+        - "all": a dictionary, keys are tuples of either (articulation point, block) or
+            (block, articulation point), values are dictionaries of information on that
+            potential constraints (keys of 'descendants', 'capacity', and 'demand').
+        - "constrained": a dictionary, keys and values are idenical to the 'all'
+            dictionary except that only entries where demand is greater than capacity
+            are contained.
+    """
+    # Build transmission graph
+    graph = nx.convert_matrix.from_pandas_edgelist(
+        branch, "from_bus_id", "to_bus_id", ["capacity"]
+    )
+    nx.set_node_attributes(graph, {k: {"demand": v} for k, v in demand.items()})
+    # Build block-cut graph of biconnected components
+    biconnected_components = list(
+        frozenset(s) for s in nx.algorithms.biconnected_components(graph)
+    )
+    articulation_points = list(nx.algorithms.articulation_points(graph))
+    bctree = nx.Graph()
+    bctree.add_nodes_from(articulation_points)
+    bctree.add_nodes_from(biconnected_components)
+    bctree.add_edges_from(
+        (a, b) for a in articulation_points for b in biconnected_components if a in b
+    )
+    # Using the largest component as the 'root', identify 'downstream' bottlenecks
+    if root is None:
+        root = frozenset(max(biconnected_components, key=len))
+    descendants = {}
+    find_descendants(graph, bctree, parent=root, grandparent=None, result=descendants)
+    # Filter out BC-tree node information, keep block/articulation pairs only
+    descendant_pairs = {k: v for k, v in descendants.items() if isinstance(k, tuple)}
+    # Identify pairs with capacity constraints
+    constrained_pairs = {
+        k: v for k, v in descendant_pairs.items() if v["demand"] > v["capacity"]
+    }
+    return {"all": descendant_pairs, "constrained": constrained_pairs}

--- a/prereise/gather/griddata/hifld/data_process/topology.py
+++ b/prereise/gather/griddata/hifld/data_process/topology.py
@@ -343,16 +343,19 @@ def find_descendants(graph, bctree, parent, grandparent, result=None):
     """
     if result is None:
         result = {}
-    result[parent] = {"descendants": set(), "demand": 0}
     children = set(bctree[parent]) - {grandparent}
     if isinstance(parent, int):
         # parent is an articulation point, children are blocks
-        result[parent]["descendants"] |= set().union(*children) - {parent}
-        result[parent]["demand"] += graph.nodes[parent]["demand"]
+        result[parent] = {
+            "descendants": set().union(*children) - {parent},
+            "demand": graph.nodes[parent]["demand"],
+        }
     else:
         # parent is a block, children are articulation points
-        result[parent]["descendants"] |= children
-        result[parent]["demand"] += sum(graph.nodes[p]["demand"] for p in parent)
+        result[parent] = {
+            "descendants": children.copy(),
+            "demand": sum(graph.nodes[p]["demand"] for p in parent),
+        }
     for child in children:
         # We need to find all descendants of the child to be able sum their demands
         child_descendants = find_descendants(graph, bctree, child, parent, result)

--- a/prereise/gather/griddata/hifld/orchestration.py
+++ b/prereise/gather/griddata/hifld/orchestration.py
@@ -11,6 +11,7 @@ from prereise.gather.griddata.hifld.data_process.profiles import (
     build_solar,
     build_wind,
 )
+from prereise.gather.griddata.hifld.data_process.topology import report_bottlenecks
 from prereise.gather.griddata.hifld.data_process.transmission import build_transmission
 
 
@@ -34,6 +35,7 @@ def create_csvs(
     hydro_kwargs,
     solar_kwargs,
     wind_kwargs,
+    zone_demand=None,
 ):
     """Process HIFLD source data to CSVs compatible with PowerSimData.
 
@@ -45,11 +47,15 @@ def create_csvs(
         :func:`prereise.gather.solardata.nsrdb.sam.retrieve_data_individual`.
     :param dict wind_kwargs: keyword arguments to pass to
         :func:`prereise.gather.griddata.hifld.data_process.profiles.build_wind`.
+    :param pandas.DataFrame zone_demand: per-zone demand profiles, used to evaluate
+        local transmission constraints. If None, this step will be skipped.
     """
     _check_profile_kwargs(
         {"hydro": hydro_kwargs, "solar": solar_kwargs, "wind": wind_kwargs}
     )
     full_tables = create_grid(output_folder)
+    if zone_demand is not None:
+        report_bottlenecks(full_tables["branch"], full_tables["bus"], zone_demand)
     create_profiles(
         full_tables["plant"],
         profile_year,


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a helper function which can identify where local transmission capacity is insufficient to meet local power needs. This was designed around seeing whether local (radial or semi-radial) transmission capacity was sufficient to import enough power from the bulk (meshed) grid, but could easily be extended to ensure that local transmission capacity is sufficient to export power to the bulk grid.

### What the code is doing
The user-facing function is `identify_bottlenecks`. It uses a branch dataframe to build a graph representing the transmission network, construct a block-cut tree of the biconnected components (see https://en.wikipedia.org/wiki/Biconnected_component#Block-cut_tree), and identify the largest biconnected component. These data structures are then passed to `find_descendants`, and the return is filtered to output all potential bottlenecks (the `"all"` key of the output dict), plus bottlenecks where demand is greater than capacity (the `"constrained"` key of the output dict).

`find_descendants` is a recursive function which starts from a `parent` node of a block-cut tree, optionally takes a `grandparent` node which indicates which direction is 'upstream', and calculates for each edge of the block-cut tree (between an articulation point and a block) whether the total branch capacity between the articulation point and the block is sufficient to meet all downstream demand. `identify_bottlenecks` passes the largest biconnected component as the root, and then `find_descendants` calculates the total demand downstream of each articulation point, by first calculating the total demand of the downstream block, etc. until it reaches the leaf nodes of the tree where there's nothing downstream, at which point the summation can start going back up the chain. Along the way back up, the set of all downstream nodes is built, and the local capacity between each articulation point and block.

### Testing
A unit test is added, based around an example from Wikipedia's page on biconnected components, plus some arbitrary demands and capacities.
![image](https://user-images.githubusercontent.com/7348392/159815676-4f07e7a8-c887-4ab0-bdda-8432b2b2e725.png)

### Usage Example/Visuals
```python
from powersimdata import Scenario
from prereise.gather.griddata.hifld.data_process.topology import identify_bottlenecks
scenario = Scenario()
scenario.set_grid("usa_tamu", "Texas")
scenario.set_base_profile("demand", "vJan2021")
peak_demand = scenario.get_bus_demand().max()
branch = scenario.get_grid().branch.rename({"rateA": "capacity"}, axis=1)
bottlenecks = identify_bottlenecks(branch, peak_demand)
```

### Time estimate
Figuring out the graph traversal logic was a pretty big headache, if I were coming at this fresh I would expect to take more than an hour to understand it. Maybe some of you have more of an intuitive feel for graph traversal algorithms though.

I'm leaving this as a draft PR for now, since this logic is ready for review but we will probably want some higher-level logic that uses the results of the `identify_bottlenecks` to aid in grid-building, besides just throwing warnings. That would require that we have demand profiles during grid-building though, which we currently don't have, so maybe we'll want to merge this now and wait for a follow-up later. I'm open to suggestions.