### PR TITLE
refactor: change pygrib to a lazy import

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ netCDF4 = "~=1.5.8"
 powersimdata = "~=0.4.4"
 nrel-pysam = "~=2.2"
 pyproj = "~=3.0"
-pygrib = "~=2.1.4"
+pygrib = {version = "~=2.1.4", sys_platform = "!= 'win32'"}
 geopandas = "*"
 rtree = "*"
 shapely = "~=1.8"

--- a/prereise/gather/winddata/hrrr/calculations.py
+++ b/prereise/gather/winddata/hrrr/calculations.py
@@ -3,7 +3,6 @@ import os
 
 import numpy as np
 import pandas as pd
-import pygrib
 from powersimdata.utility.distance import ll2uv
 from scipy.spatial import KDTree
 from tqdm import tqdm
@@ -32,6 +31,11 @@ def get_wind_data_lat_long(dt, directory):
     :return: (*tuple*) -- A tuple of 2 same lengthed numpy arrays, first one being
         latitude and second one being longitude.
     """
+    try:
+        import pygrib
+    except ImportError:
+        print("pygrib is missing but required for this function")
+        raise
     gribs = pygrib.open(os.path.join(directory, formatted_filename(dt)))
     grib = next(gribs)
     return grib.latlons()
@@ -81,6 +85,11 @@ def extract_wind_speed(wind_farms, start_dt, end_dt, directory):
         dt1   speed       speed
         dt2   speed       speed
     """
+    try:
+        import pygrib
+    except ImportError:
+        print("pygrib is missing but required for this function")
+        raise
     wind_data_lat_long = get_wind_data_lat_long(start_dt, directory)
     wind_farm_to_closest_wind_grid_indices = find_closest_wind_grids(
         wind_farms, wind_data_lat_long

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ black
 pytest
 coverage
 pytest-cov
-pygrib~=2.1.4
+pygrib~=2.1.4; sys_platform != "win32"
 geopandas
 rtree
 shapely~=1.8


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Avoid importing `pygrib` when it's not necessary. This package is hard or impossible to install in a Windows environment, due to a dependence on compiled ECCODES code, so delaying the import should prevent problems when trying to use unrelated parts of the package.

### What the code is doing
Within `calculations.py`: moving the `pygrib` import within the functions that need it, rather than at module level. There should be no change in functionality.

Within `test_calculations.py`: refactoring how pygrib is mocked to account for the new behavior within `calculate_pout_blended`.

### Time estimate
5 minutes, maybe longer if someone wants to propose an alternative that achieves the same thing.
