### PR TITLE
feat: when loading HIFLD transmission lines, join disconnected line segments

### DIFF
--- a/prereise/gather/griddata/hifld/data_access/tests/test_load.py
+++ b/prereise/gather/griddata/hifld/data_access/tests/test_load.py
@@ -1,0 +1,78 @@
+from prereise.gather.griddata.hifld.data_access.load import _join_line_segments
+
+
+def test_join_line_segments_single_segment():
+    # Seattle to Tacoma via Seatac
+    segments = [[(-122.34, 47.60), (-122.30, 47.44), (-122.44, 47.25)]]
+    assert _join_line_segments(segments) is segments[0]
+
+
+def test_join_line_segments_single_segment_after_filtering():
+    segments = [
+        # Long line with extremely similar start & end in Tacoma, should get filtered
+        [(-122.45, 47.24), (-122.90, 47.04), (-122.45, 47.240001)],
+        # Seattle to Tacoma via Seatac
+        [(-122.34, 47.60), (-122.30, 47.44), (-122.44, 47.25)],
+    ]
+    assert _join_line_segments(segments) is segments[1]
+
+
+def test_join_line_segments_two_segments():
+    segments = [
+        # Seattle to Tacoma via Seatac
+        [(-122.34, 47.60), (-122.30, 47.44), (-122.44, 47.25)],
+        # Olympia to a slightly different point in Tacoma
+        [(-122.90, 47.04), (-122.45, 47.24)],
+    ]
+    joined_segments = _join_line_segments(segments)
+    assert joined_segments == [
+        (-122.34, 47.60),
+        (-122.30, 47.44),
+        (-122.44, 47.25),
+        (-122.45, 47.24),
+        (-122.90, 47.04),
+    ]
+
+
+def test_join_line_segments_three_segments():
+    segments = [
+        # Olympia to Tacoma
+        [(-122.90, 47.04), (-122.45, 47.24)],
+        # Seattle to a slightly different point in Tacoma via Seatac
+        [(-122.34, 47.60), (-122.30, 47.44), (-122.44, 47.25)],
+        # Seattle (exact same point) to Everett
+        [(-122.34, 47.60), (-122.18, 47.99)],
+    ]
+    joined_segments = _join_line_segments(segments)
+    assert joined_segments == [
+        (-122.90, 47.04),
+        (-122.45, 47.24),
+        (-122.44, 47.25),
+        (-122.30, 47.44),
+        (-122.34, 47.60),
+        (-122.34, 47.60),
+        (-122.18, 47.99),
+    ]
+
+
+def test_join_line_segments_four_segments_non_linear():
+    segments = [
+        # Olympia to Tacoma
+        [(-122.90, 47.04), (-122.45, 47.24)],
+        # Seattle to Bellevue via Kenmore (should be dropped)
+        [(-122.34, 47.60), (-122.253, 47.755), (-122.195, 47.603)],
+        # Seattle to a slightly different point in Tacoma via Seatac
+        [(-122.34, 47.60), (-122.30, 47.44), (-122.44, 47.25)],
+        # Seattle (exact same point) to Everett
+        [(-122.34, 47.60), (-122.18, 47.99)],
+    ]
+    joined_segments = _join_line_segments(segments)
+    assert joined_segments == [
+        (-122.90, 47.04),
+        (-122.45, 47.24),
+        (-122.44, 47.25),
+        (-122.30, 47.44),
+        (-122.34, 47.60),
+        (-122.34, 47.60),
+        (-122.18, 47.99),
+    ]

--- a/prereise/gather/helpers.py
+++ b/prereise/gather/helpers.py
@@ -1,5 +1,5 @@
 import os
-from math import cos, radians, sin
+from math import acos, cos, degrees, radians, sin
 
 import numpy as np
 import pandas as pd
@@ -116,3 +116,20 @@ def latlon_to_xyz(latitude, longitude):
     uv = [cos_lat * cos_lon, cos_lat * sin_lon, sin_lat]
 
     return uv
+
+
+def angular_distance(uv1, uv2):
+    """Calculate the angular distance between two vectors.
+
+    :param list uv1: 3-components vector as returned by :func:`latlon_to_xyz`.
+    :param list uv2: 3-components vector as returned by :func:`latlon_to_xyz`.
+    :return: (*float*) -- angle (in radians).
+    """
+    cos_angle = uv1[0] * uv2[0] + uv1[1] * uv2[1] + uv1[2] * uv2[2]
+    if cos_angle >= 1:
+        cos_angle = 1
+    if cos_angle <= -1:
+        cos_angle = -1
+    angle = degrees(acos(cos_angle))
+
+    return angle


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The HIFLD transmission line paths are defined by either: a list of lat/lon points (which I'll call a 'segment' from hereon out), or a list of such lists. The Jul 2020 dataset values seem to _always_ be a list of segments, but the February 2020 dataset is either a single segment (not wrapped in a list) or a list of segments.

Previously, when we had a list of segments, we always grabbed the first one, discarding all the rest. This PR changes the logic so that _if_ we get a list of segments of length greater than one, we make an assumption about how to reconnect them. The logic is a little complex because the segments aren't 'drawn' in any particular order, don't necessary connect, and there are some small noisy segments that need to be discarded.

### What the code is doing
Within `helpers.py`, we copy over a couple of helper functions for calculating distances between coordinate pairs.

Within `load.py`, we add a new function `_join_line_segments` to take a list of segments and parse them.
- There is a private function `_generate_linear_spanning_tree` which:
  - creates a graph with each segment's endpoints as nodes and an edge between the start and end of each segment
  - creates edges between each endpoint of each segment and each endpoint of each other segment, weighted by distance
  - find the minimum spanning tree of the graph
  - raises an error if the minimum spanning tree isn't a chain (not sure if this is the right graph theory terminology or not)
  - returns the minimum spanning tree if not
- The list of segments is passed to `_generate_linear_spanning_tree`, and if the tree isn't a chain, the smallest segment is dropped and the process is repeated until we have a chain tree.
- The final list of segments is processed to put all of the coordinate pairs into the proper order, by traversing the tree and flipping the original segments if they go from 'end' to 'start' rather than 'start' to 'end'.

### Testing
Tested manually. Calling `get_hifld_electric_power_transmission_lines` works, as well as `create_grid`.

### Time estimate
30-60 minutes. The code is not too complex, but the logic is, since it needs to handle many edge cases found in the source data.