### PR TITLE
feat: add function to create shapefiles with urban and rural areas

### DIFF
--- a/prereise/utility/generate_rural_shapefiles.py
+++ b/prereise/utility/generate_rural_shapefiles.py
@@ -1,0 +1,69 @@
+import os
+import geopandas as gpd
+
+from prereise.gather.const import abv2state
+from prereise.utility.shapefile import download_shapefiles
+
+
+def append_rural_areas_to_urban(states, urban_areas):
+    """Takes shapefiles of US States and US urban areas, processes the files,
+    and adds rural areas (areas that are not urban) to the geodataframe
+
+    :param geopandas.geodataframe.GeoDataFrame states: US state outlines
+    :param geopandas.geodataframe.GeoDataFrame urban_areas: US urban area outlines
+    :return: (*geopandas.geodataframe.GeoDataFrame*) -- new gdf of urban and rural areas
+        includes a column indicating whether the area is urban or not
+    """
+    lower_48_states_abv = list(abv2state.keys())
+    lower_48_states_abv.remove("AK")
+    lower_48_states_abv.remove("HI")
+
+    states = states.rename(columns={"STUSPS": "state"})
+    states = states.loc[states["state"].isin(lower_48_states_abv)]
+
+    urban_areas["state"] = urban_areas["NAME10"].str[-2:]
+    # this drops 66 out of 3601 rows
+    urban_areas = urban_areas.loc[urban_areas["state"].isin(lower_48_states_abv)]
+    urban_areas["urban"] = True
+
+    rural_areas = states.overlay(urban_areas, how="difference")
+    rural_areas["urban"] = False
+
+    return urban_areas.append(rural_areas, ignore_index=True)[
+        ["state", "geometry", "urban"]
+    ]
+
+
+def generate_urban_and_rural_shapefiles():
+    """Downloads shapefiles of state outlines and urban areas from BES azure blob storage
+    Writes these shapefiles to a local folder, then creates new shapefiles that
+    include both urban and rural areas
+
+    :return: (*str*) path to the new shapefiles
+    """
+
+    base_url = "https://besciences.blob.core.windows.net"
+
+    states_folder = os.path.join(os.path.dirname(__file__), "state_shapefiles")
+    states_file = download_shapefiles(
+        f"{base_url}/us-shapefiles/",
+        "cb_2018_us_state_20m",
+        states_folder,
+        overwrite=True,
+    )
+    states = gpd.read_file(states_file)
+
+    urban_folder = os.path.join(os.path.dirname(__file__), "urban_shapefiles")
+    urban_file = download_shapefiles(
+        f"{base_url}/shapefiles/urban-area-shapefiles/",
+        "cb_2019_us_ua10_500k",
+        urban_folder,
+    )
+    urban_areas = gpd.read_file(urban_file)
+
+    urban_and_rural_areas = append_rural_areas_to_urban(states, urban_areas)
+
+    os.makedirs("./urban_and_rural_shapefiles", exist_ok=True)
+    filepath = "./urban_and_rural_shapefiles/urban_and_rural_areas.shp"
+    urban_and_rural_areas.to_file(filepath)
+    return filepath

--- a/prereise/utility/generate_rural_shapefiles.py
+++ b/prereise/utility/generate_rural_shapefiles.py
@@ -1,4 +1,5 @@
 import os
+
 import geopandas as gpd
 
 from prereise.gather.const import abv2state
@@ -7,7 +8,7 @@ from prereise.utility.shapefile import download_shapefiles
 
 def append_rural_areas_to_urban(states, urban_areas):
     """Takes shapefiles of US States and US urban areas, processes the files,
-    and adds rural areas (areas that are not urban) to the geodataframe
+    and adds rural areas (areas that are not urban) to the geodataframe.
 
     :param geopandas.geodataframe.GeoDataFrame states: US state outlines
     :param geopandas.geodataframe.GeoDataFrame urban_areas: US urban area outlines
@@ -35,9 +36,9 @@ def append_rural_areas_to_urban(states, urban_areas):
 
 
 def generate_urban_and_rural_shapefiles():
-    """Downloads shapefiles of state outlines and urban areas from BES azure blob storage
+    """Downloads shapefiles of state outlines and urban areas from BES azure blob storage.
     Writes these shapefiles to a local folder, then creates new shapefiles that
-    include both urban and rural areas
+    include both urban and rural areas.
 
     :return: (*str*) path to the new shapefiles
     """

--- a/prereise/utility/generate_rural_shapefiles.py
+++ b/prereise/utility/generate_rural_shapefiles.py
@@ -42,7 +42,6 @@ def generate_urban_and_rural_shapefiles():
 
     :return: (*str*) path to the new shapefiles
     """
-
     base_url = "https://besciences.blob.core.windows.net"
 
     states_folder = os.path.join(os.path.dirname(__file__), "state_shapefiles")
@@ -50,7 +49,6 @@ def generate_urban_and_rural_shapefiles():
         f"{base_url}/us-shapefiles/",
         "cb_2018_us_state_20m",
         states_folder,
-        overwrite=True,
     )
     states = gpd.read_file(states_file)
 

--- a/prereise/utility/generate_rural_shapefiles.py
+++ b/prereise/utility/generate_rural_shapefiles.py
@@ -7,8 +7,9 @@ from prereise.utility.shapefile import download_shapefiles
 
 
 def append_rural_areas_to_urban(states, urban_areas):
-    """Takes shapefiles of US States and US urban areas, processes the files,
-    and adds rural areas (areas that are not urban) to the geodataframe.
+    """Takes shapefiles of US States and US urban areas, filters to the
+    contiguous 48 states, and adds rural areas (areas that are not urban) to
+    the geodataframe.
 
     :param geopandas.geodataframe.GeoDataFrame states: US state outlines
     :param geopandas.geodataframe.GeoDataFrame urban_areas: US urban area outlines

--- a/prereise/utility/generate_rural_shapefiles.py
+++ b/prereise/utility/generate_rural_shapefiles.py
@@ -41,21 +41,21 @@ def generate_urban_and_rural_shapefiles():
     Writes these shapefiles to a local folder, then creates new shapefiles that
     include both urban and rural areas.
 
-    :return: (*str*) path to the new shapefiles
+    :return: (*str*) -- path to the new shapefiles
     """
-    base_url = "https://besciences.blob.core.windows.net"
+    base_url = "https://besciences.blob.core.windows.net/shapefiles/USA/"
 
-    states_folder = os.path.join(os.path.dirname(__file__), "state_shapefiles")
+    states_folder = os.path.join(os.path.dirname(__file__), "state-outlines")
     states_file = download_shapefiles(
-        f"{base_url}/us-shapefiles/",
+        f"{base_url}state-outlines/",
         "cb_2018_us_state_20m",
         states_folder,
     )
     states = gpd.read_file(states_file)
 
-    urban_folder = os.path.join(os.path.dirname(__file__), "urban_shapefiles")
+    urban_folder = os.path.join(os.path.dirname(__file__), "urban-areas")
     urban_file = download_shapefiles(
-        f"{base_url}/shapefiles/urban-area-shapefiles/",
+        f"{base_url}urban-areas/",
         "cb_2019_us_ua10_500k",
         urban_folder,
     )
@@ -63,7 +63,7 @@ def generate_urban_and_rural_shapefiles():
 
     urban_and_rural_areas = append_rural_areas_to_urban(states, urban_areas)
 
-    os.makedirs("./urban_and_rural_shapefiles", exist_ok=True)
-    filepath = "./urban_and_rural_shapefiles/urban_and_rural_areas.shp"
+    os.makedirs("./urban-and-rural-areas", exist_ok=True)
+    filepath = "./urban-and-rural-areas/urban-and-rural-areas.shp"
     urban_and_rural_areas.to_file(filepath)
     return filepath

--- a/prereise/utility/shapefile.py
+++ b/prereise/utility/shapefile.py
@@ -4,7 +4,7 @@ import urllib
 
 # Mostly copied from download_states_shapefile in postreise.plot.plot_states
 def download_shapefiles(url_base, shape_filename, base_filepath, overwrite=False):
-    """Downloads shapefiles from url
+    """Downloads shapefiles from url and writes them to a local folder.
 
     :param str url_base: URL to folder containing shapefiles. Must include foward slash at end.
     :param str shape_filename: all shapefiles in folder must have the same name

--- a/prereise/utility/shapefile.py
+++ b/prereise/utility/shapefile.py
@@ -12,7 +12,6 @@ def download_shapefiles(url_base, shape_filename, base_filepath, overwrite=False
     :param bool overwrite: Whether to overwrite existing files, defaults to False
     :return: (*str*)  -- path to shapefile
     """
-
     os.makedirs(base_filepath, exist_ok=True)
     shape_entensions = ["cpg", "dbf", "prj", "shp", "shx"]
 

--- a/prereise/utility/shapefile.py
+++ b/prereise/utility/shapefile.py
@@ -1,0 +1,31 @@
+import os
+import urllib
+
+
+# Mostly copied from download_states_shapefile in postreise.plot.plot_states
+def download_shapefiles(url_base, shape_filename, base_filepath, overwrite=False):
+    """Downloads shapefiles from url
+
+    :param str url_base: URL to folder containing shapefiles. Must include foward slash at end.
+    :param str shape_filename: all shapefiles in folder must have the same name
+    :param str base_filepath: folder to save files
+    :param bool overwrite: Whether to overwrite existing files, defaults to False
+    :return: (*str*)  -- path to shapefile
+    """
+
+    os.makedirs(base_filepath, exist_ok=True)
+    shape_entensions = ["cpg", "dbf", "prj", "shp", "shx"]
+
+    for ext in shape_entensions:
+        filepath = os.path.join(base_filepath, f"{shape_filename}.{ext}")
+
+        if not os.path.isfile(filepath) or overwrite:
+            response = urllib.request.urlopen(f"{url_base}{shape_filename}.{ext}")
+
+            with open(filepath, "wb") as f:
+                f.write(response.read())
+        else:
+            print(f"Skipping {filepath} because it already exists.")
+
+    filename = os.path.join(base_filepath, f"{shape_filename}.shp")
+    return filename

--- a/prereise/utility/tests/test_generate_rural_shapefiles.py
+++ b/prereise/utility/tests/test_generate_rural_shapefiles.py
@@ -1,0 +1,72 @@
+import json
+
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Polygon
+
+from prereise.utility.generate_rural_shapefiles import append_rural_areas_to_urban
+
+
+def test_append_rural_areas_to_urban():
+    mock_states = gpd.GeoDataFrame(
+        {
+            "geometry": [
+                Polygon([(0, 0), (0, 5), (5, 5), (5, 0)]),
+            ],
+            "STUSPS": ["CO"],
+        }
+    )
+    mock_urban = gpd.GeoDataFrame(
+        {
+            "geometry": [
+                Polygon([(0.1, 0.1), (0.1, 0.5), (0.5, 0.5), (0.5, 0.1)]),
+                Polygon([(4, 4), (4, 4.5), (4.5, 4.5), (4.5, 4)]),
+                Polygon([(10, 10), (10, 13), (13, 13), (13, 10)]),
+            ],
+            "NAME10": ["Denver_CO", "Boulder_CO", "Honolulu_HI"],
+        }
+    )
+
+    r_and_u = append_rural_areas_to_urban(mock_states, mock_urban)
+
+    # Convert to json then back to dict -- this unpacks the Polygon objects
+    assert json.loads(r_and_u.to_json()) == {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "id": "0",
+                "type": "Feature",
+                "properties": {"state": "CO", "urban": True},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[0.1, 0.1], [0.1, 0.5], [0.5, 0.5], [0.5, 0.1], [0.1, 0.1]]
+                    ],
+                },
+            },
+            {
+                "id": "1",
+                "type": "Feature",
+                "properties": {"state": "CO", "urban": True},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[4.0, 4.0], [4.0, 4.5], [4.5, 4.5], [4.5, 4.0], [4.0, 4.0]]
+                    ],
+                },
+            },
+            {
+                "id": "2",
+                "type": "Feature",
+                "properties": {"state": "CO", "urban": False},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[5.0, 5.0], [5.0, 0.0], [0.0, 0.0], [0.0, 5.0], [5.0, 5.0]],
+                        [[4.5, 4.0], [4.5, 4.5], [4.0, 4.5], [4.0, 4.0], [4.5, 4.0]],
+                        [[0.5, 0.5], [0.1, 0.5], [0.1, 0.1], [0.5, 0.1], [0.5, 0.5]],
+                    ],
+                },
+            },
+        ],
+    }

--- a/prereise/utility/tests/test_generate_rural_shapefiles.py
+++ b/prereise/utility/tests/test_generate_rural_shapefiles.py
@@ -1,7 +1,6 @@
 import json
 
 import geopandas as gpd
-import pandas as pd
 from shapely.geometry import Polygon
 
 from prereise.utility.generate_rural_shapefiles import append_rural_areas_to_urban


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Addresses https://github.com/Breakthrough-Energy/PreREISE/issues/273
Adds function to create shapefiles for urban areas and rural areas for each state

### What the code is doing
- Adds a function to download shapefiles from a URL, mostly copied from [PostREISE](https://github.com/Breakthrough-Energy/PostREISE/blob/6f46f6e871ba763064a1616642b01c91903eba05/postreise/plot/plot_states.py)
- Adds a function to take shapefiles of US states and urban areas and returns a geodataframe of both urban and rural areas.
- Adds a function to do the whole thing at once - download files, process data, and write new files.

### Testing
TBD 

### Where to look
* It's helpful to clarify where your new code lives if you moved files around or there could be confusion/

* What files are most important?

### Usage Example/Visuals
How the code can be used and/or images of any graphs, tables or other visuals (not always applicable). 

### Time estimate
10 mins
