### PR TITLE
feat: add lines to HIFLD dataset before further processing

### DIFF
--- a/prereise/gather/griddata/hifld/const.py
+++ b/prereise/gather/griddata/hifld/const.py
@@ -459,6 +459,23 @@ proxy_substations = [
     },
 ]
 
+proxy_lines = [
+    {
+        "SUB_1_ID": 301352,
+        "SUB_2_ID": 308812,
+        "VOLTAGE": 138,
+        "circuits": 2,
+        "conductors": 2,
+    },
+    {
+        "SUB_1_ID": 309418,
+        "SUB_2_ID": 308608,
+        "VOLTAGE": 138,
+        "circuits": 2,
+        "conductors": 1,
+    },
+]
+
 substations_lines_filter_override = {301995}
 
 seams_substations = {

--- a/prereise/gather/griddata/hifld/data_process/transmission.py
+++ b/prereise/gather/griddata/hifld/data_process/transmission.py
@@ -644,14 +644,19 @@ def add_lines_impedances_ratings(branch, line_overrides=None):
     }
     # Add meaningful index for easier lookups using design tuples
     tower_designs.set_index(["voltage", "circuits", "bundle_count"], inplace=True)
-    # Map each transmission line to its corresponding Tower design, and build a Line
+    # Map each transmission line to an assumed Tower design
+    line_to_design = branch.apply(
+        lambda x: line_overrides.get(x.name, closest_voltage_design[x["VOLTAGE"]]),
+        axis=1,
+    )
+    if "line_design_assumptions" in branch:
+        # If some lines already have design assumptions, prefer these
+        line_to_design.update(branch["line_design_assumptions"])
+    # Now that we have a tower design for each line, create a Line with additional info
     branch_plus_line_designs = branch.assign(
         line_object=branch.apply(
             lambda x: Line(
-                tower=tower_designs.loc[
-                    line_overrides.get(x.name, closest_voltage_design[x["VOLTAGE"]]),
-                    "Tower",
-                ],
+                tower=tower_designs.loc[line_to_design[x.name], "Tower"],
                 voltage=x["VOLTAGE"],
                 length=x["length"],
             ),
@@ -672,6 +677,45 @@ def add_lines_impedances_ratings(branch, line_overrides=None):
     branch["rateA"] = branch_plus_line_designs["line_object"].map(
         lambda x: x.power_rating
     )
+
+
+def add_proxy_lines(branch, substation, proxy_lines=None):
+    """Given a set of proxy lines, join these data with the existing branch data.
+
+    :param pandas.Dataframe branch: existing branch data.
+    :param pandas.Dataframe substation: substation data. Required columns are 'LATITUDE'
+        and 'LONGITUDE'.
+    :param list/dict/pandas.DataFrame: information on the new branches to be added. This
+        input can be a list of dictionaries or any other input that can be used to
+        instantiate a pandas DataFrame (including another pandas DataFrame). If this is
+        None, an unmodified copy of the ``branch`` data frame will be returned.
+    :raises ValueError: if any substations IDs from ``proxy_lines`` aren't present
+        within the index of ``substation``.
+    :return: (*pandas.DataFrame*) -- a combined data frame of existing and new lines.
+        If ``proxy_lines`` is non-empty, this returned data frame will contain a
+        'line_design_assumptions' column, with (voltage, circuits, conductors) tuples.
+    """
+    if proxy_lines is None or len(proxy_lines) == 0:
+        return branch.copy()
+    proxy_lines_df = pd.DataFrame(proxy_lines)
+    all_proxy_line_subs = set(proxy_lines_df["SUB_1_ID"]) | set(
+        proxy_lines_df["SUB_2_ID"]
+    )
+    if not all_proxy_line_subs <= set(substation.index):
+        missing = all_proxy_line_subs - set(substation.index)
+        raise ValueError(f"Some proxy lines have non-matching substations: {missing=}")
+    proxy_lines_df["COORDINATES"] = proxy_lines_df.apply(
+        lambda x: [
+            substation.loc[x["SUB_1_ID"], ["LATITUDE", "LONGITUDE"]].tolist(),
+            substation.loc[x["SUB_2_ID"], ["LATITUDE", "LONGITUDE"]].tolist(),
+        ],
+        axis=1,
+    )
+    proxy_lines_df["line_design_assumptions"] = proxy_lines_df[
+        ["VOLTAGE", "circuits", "conductors"]
+    ].apply(tuple, axis=1)
+    proxy_lines_df.index += branch.index.max() + 1
+    return pd.concat([branch, proxy_lines_df])
 
 
 def estimate_transformers(bus_pair, lines, bus_voltages, transformer_designs):
@@ -889,6 +933,9 @@ def build_transmission(method="line2sub", **kwargs):
             substations, hifld_lines, **kwargs
         )
 
+    # Add proxy lines
+    lines = add_proxy_lines(lines, substations, const.proxy_lines)
+    # Add lines required to connect islands
     lines, substations = filter_islands_and_connect_with_mst(
         lines, substations, **island_kwargs
     )


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add the ability to append the existing HIFLD lines dataset with additional manually-defined lines. This allows us to fill in parts of the grid where we know there are transmission lines, but these lines are missing for whatever reason. This should be at least partial fulfillment of #234; we get the capability to manually add lines, but we don't yet have a full set of required lines to connect urban areas with lots of undergrounding, or logic to estimate their connectivity.

### What the code is doing
- We add a new function `add_proxy_lines` which takes data from const.py and uses it to populate required information to add to the `branch` data frame. It adds one new column `"line_design_assumptions"` which will get used in the refactored version of `add_lines_impedances_ratings`.
- Within `add_lines_impedances_ratings`, we modify the logic so that we first identify the design for each transmission line (using either the default for that voltage or the defined overrides), then we check for a `"line_design_assumptions"` column and if this is present, override the design with the design tuple from this column, and then finally use the aggregated design mapping to create a `Line` object for each branch so that we can estimate rating and impedance. This way, the data in const.py can have non-default designs without needing to use the existing `{branch_id: design}` mapping schema in const.py, since we won't know the ID of these newly-added lines in advance (their IDs get generated based on the max ID of the other branches).
- Within `build_transmission`, we call `add_proxy_lines` before we connect the branches via the minimum spanning tree, so that manually-defined branches which connect islands will avoid the logic which would otherwise create new branches. This way, even if a branch would get added via the minimum spanning tree logic, it can be entirely replaced with a different branch if we want the branch to have different characteristics.

### Testing
Tested manually.

### Time estimate
30 minutes. ~This is a draft PR for now, since it relies on code in #286.~
