### PR TITLE
fix: negative dwell time calculation in data processing

### DIFF
--- a/prereise/gather/demanddata/transportation_electrification/data_process.py
+++ b/prereise/gather/demanddata/transportation_electrification/data_process.py
@@ -4,7 +4,9 @@ import pandas as pd
 
 
 def calculate_dwell_time(data: pd.DataFrame):
-    """Calculates the dwell time, how long a vehicle has been charging
+    """Calculates the dwell time, how long a vehicle has been charging. For the last
+    trip, dwell time is calculated based on the last trip's end time and the start
+    time of the first trip. This calculation handles when start times begin past 12AM.
 
     :param pandas.DataFrame data: the data to calculate the dwell time from
     :return: (*pandas.Series*) -- list of dwell times
@@ -14,10 +16,10 @@ def calculate_dwell_time(data: pd.DataFrame):
         - data["End time (hour decimal)"].iloc[:-1]
     )
     dwells.loc[data.index[-1]] = (
-        24
+        data["Start time (hour decimal)"].iloc[0]
         - data["End time (hour decimal)"].iloc[-1]
-        + data["Start time (hour decimal)"].iloc[0]
     )
+    dwells[dwells < 0] += 24
 
     return dwells
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
What is the larger goal of this change?
To update the dwell time calculation in the original data processing code.

### What the code is doing
How is the purpose executed?
The dwell times are calculated by subtracting the current trip's end time from the next trip's start time. The last trip's dwell time is calculated by subtracting it's end time from the first trip's start time. This updated calculation also handles when start times begin past 12AM for all trips, which the previous version didn't handle and outputted negative times.

### Testing
How did you test this change (unit/functional testing, manual testing, etc.)? 
Since the output should not contain negative values (which the original code produced), some of the trips with the negative values were manually recalculated. Those were then used as test cases to compare against the updated code output.

### Where to look
* It's helpful to clarify where your new code lives if you moved files around or there could be confusion/
PreREISE/prereise/gather/demanddata/transportation_electrification/data_process.py

* What files are most important?
data_process.py

### Usage Example/Visuals
How the code can be used and/or images of any graphs, tables or other visuals (not always applicable). 

### Time estimate
How long will it take for reviewers and observers to understand this code change?
It should take maybe 15 minutes to 30 minutes to understand.