### PR TITLE
Add Slack badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/Breakthrough-Energy/PreREISE/develop?logo=GitHub)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/Breakthrough-Energy/PreREISE?logo=GitHub)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Code of Conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat)](https://breakthrough-energy.github.io/docs/communication/code_of_conduct.html)
+[![Code of Conduct](https://img.shields.io/badge/Code_of_conduct-ff69b4.svg)](https://breakthrough-energy.github.io/docs/communication/code_of_conduct.html)
+[![Slack](https://img.shields.io/badge/Community_Slack-sign_up-1f425f.svg?logo=slack)](https://science.breakthroughenergy.org/#get-updates)
 
 
 # PreREISE


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a Slack badge in README. Also modified the code of conduct one in order to highlight code of conduct with a single color and not two

### What the code is doing
N/A

### Testing
N/A

### Where to look
The header of the README

### Usage Example/Visuals
Same as in Breakthrough-Energy/PowerSimData#696

### Time estimate
2min

