### PR TITLE
Calculate urban and rural annual VMT fractions

### DIFF
--- a/prereise/gather/demanddata/transportation_electrification/generate_scaling_factors.py
+++ b/prereise/gather/demanddata/transportation_electrification/generate_scaling_factors.py
@@ -1,0 +1,211 @@
+import warnings
+
+import pandas as pd
+from powersimdata.network.constants.region.geography import USA
+
+warnings.simplefilter(action="ignore", category=UserWarning)
+
+census_ua_url = "https://www2.census.gov/geo/docs/reference/ua/ua_st_list_all.xls"
+census_state_url = "https://www2.census.gov/programs-surveys/popest/tables/2010-2019/state/totals/nst-est2019-01.xlsx"
+tht_data_url = "https://www7.transportation.gov/file/51021/download?token=2nJBkBSM"
+
+state2abv = USA().state2abv | {"District of Columbia": "DC"}
+id2state = {
+    "01": "AL",
+    "02": "AK",
+    "04": "AZ",
+    "05": "AR",
+    "06": "CA",
+    "08": "CO",
+    "09": "CT",
+    "10": "DE",
+    "11": "DC",
+    "12": "FL",
+    "13": "GA",
+    "15": "HI",
+    "16": "ID",
+    "17": "IL",
+    "18": "IN",
+    "19": "IA",
+    "20": "KS",
+    "21": "KY",
+    "22": "LA",
+    "23": "ME",
+    "24": "MD",
+    "25": "MA",
+    "26": "MI",
+    "27": "MN",
+    "28": "MS",
+    "29": "MO",
+    "30": "MT",
+    "31": "NE",
+    "32": "NV",
+    "33": "NH",
+    "34": "NJ",
+    "35": "NM",
+    "36": "NY",
+    "37": "NC",
+    "38": "ND",
+    "39": "OH",
+    "40": "OK",
+    "41": "OR",
+    "42": "PA",
+    "44": "RI",
+    "45": "SC",
+    "46": "SD",
+    "47": "TN",
+    "48": "TX",
+    "49": "UT",
+    "50": "VT",
+    "51": "VA",
+    "53": "WA",
+    "54": "WV",
+    "55": "WI",
+    "56": "WY",
+}
+
+
+def load_census_ua(path):
+    """Load census data for urban population
+
+    :param str path: path to census file (local or url)
+    :return: (*dict*) -- keys are state abbreviation and values are data frames giving
+        population by urban area in the state.
+    """
+    df = pd.read_excel(
+        path,
+        index_col=0,
+        keep_default_na=False,
+        usecols=[1, 2, 4],
+        skiprows=2,
+    )
+    state2ua = {}
+    for n, s in id2state.items():
+        state2ua[s] = df.query("STATE==@n")["POP"]
+
+    return state2ua
+
+
+def load_census_state(path, year=None):
+    """Load census data for state population
+
+    :param str path: path to census file (local or url)
+    :param str year: year to query for state population.
+    :return: (*pandas.Series*) -- indices are state abbreviations and values are
+        population in state
+    """
+    if year is None:
+        year = 2015
+
+    df = pd.read_excel(path, skiprows=3, index_col=0, skipfooter=7)
+    df.index = df.index.map(lambda x: str(x)[1:])
+
+    return df.loc[state2abv.keys()][year].rename(index=state2abv)
+
+
+def load_dot_vmt_per_capita(path):
+    """Load Vehicle Miles Traveled (VMT) per capita in urban areas
+
+    :param str path: path to Department of Transportation's Transportation Health Tools
+        (local or url)
+    :return: (*tuple*) -- series. Indices are state abbreviations and values are
+        VMT per capita in urban area (first element) or state (second element)
+    """
+    df_ua = pd.read_excel(
+        path,
+        sheet_name="Urbanized Area",
+        index_col=0,
+        usecols=[0, 3],
+        names=["UA", "VMT per Capita (daily)"],
+    )
+
+    df_state = pd.read_excel(
+        path,
+        sheet_name="State",
+        index_col=0,
+        usecols=[0, 39],
+        names=["State", "VMT per Capita (annual)"],
+    )
+
+    return (
+        df_ua.squeeze().loc[lambda x: x != "[no data]"],
+        df_state.rename(index=state2abv).squeeze(),
+    )
+
+
+def calculate_vmt_for_ua(census_ua, tht_ua):
+    """Calculate the total annual Vehicle Miles Traveled (VMT) in urban areas
+
+    :param dict census_ua: dictionary as returned by :func:`load_census_ua`
+    :param pandas.Series tht_ua: vmt per capita in urban areas as returned by
+        :func:`load_dot_vmt_per_capita`
+    :return: (*dict*) -- keys are state abbreviations and values are series giving
+        annual vmt by urban areas.
+    """
+
+    tht_ua_format = tht_ua.copy()
+    vmt_for_ua = {}
+
+    tht_ua_format.index = tht_ua_format.index.str.replace(r"[, -.]", "", regex=True)
+    format2original = dict(zip(tht_ua_format.index, tht_ua.index))
+
+    for s in census_ua:
+        census_ua_format = census_ua[s].copy()
+        census_ua_format.index = census_ua_format.index.str.replace(
+            r"[, -.]", "", regex=True
+        )
+        common = set(tht_ua_format.index).intersection(set(census_ua_format.index))
+        vmt_for_ua[s] = (
+            pd.DataFrame(
+                {
+                    "Annual VMT": [
+                        365 * tht_ua_format.loc[i] * census_ua_format.loc[i]
+                        for i in common
+                    ]
+                },
+                index=list(common),
+            )
+            .rename(index=format2original)
+            .squeeze()
+        )
+
+    return vmt_for_ua
+
+
+def calculate_vmt_for_state(census_state, tht_state):
+    """Calculate the total annual Vehicle Miles Traveled (VMT) in states
+
+    :param dict census_state: dictionary as returned by :func:`load_census_state`
+    :param pandas.Series tht_state: vmt per capita in states as returned by
+        :func:`load_dot_vmt_per_capita`
+    :return: (*pandas.Series*) -- indices are state abbreviations and values are annual
+        VMT in state.
+    """
+    common = list(set(tht_state.index).intersection(set(census_state.index)))
+    vmt_for_state = tht_state.loc[common] * census_state.loc[common]
+
+    return vmt_for_state
+
+
+def calculate_urban_rural_fraction(vmt_for_ua, vmt_for_state):
+    """Calculate the percentage of Vehicle Miles Traveled (VMT) in urban and rural areas
+
+    :param dict vmt_for_ua: dictionary as returned by :func:`calculate_vmt_for_ua`.
+    :param pandas.Series vmt_for_state: series as returned by
+        :func:`calculate_vmt_for_state`
+    :return: (*tuple*) -- keys are state abbreviations and values are either series of
+        percentage vmt in urban areas (first element) or percentage in rural area
+        (second element)
+    """
+    vmt_for_ua_perc = vmt_for_ua.copy()
+    vmt_for_ra_perc = {}
+    for s in vmt_for_ua:
+        if s in vmt_for_state.index:
+            vmt_for_ua_perc[s] = vmt_for_ua[s] / vmt_for_state.loc[s]
+            vmt_for_ra_perc[s] = 1 - vmt_for_ua_perc[s].sum()
+        # Handle District of Columbia
+        else:
+            vmt_for_ua_perc[s] = 1
+            vmt_for_ra_perc[s] = 0
+
+    return vmt_for_ua_perc, vmt_for_ra_perc


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Calculate urban and rural Vehicle Miles Traveled (VMT) fractions. Closes #316 and #317.

### What the code is doing
* Load 3 dataset (census data for state and urban area and the transportation health tool) with 2 different functions
* Calculate  the total annual Vehicle Miles Traveled (VMT) in urban areas and states
* Calculate the percentage of Vehicle Miles Traveled (VMT) in urban and rural areas

### Testing
Existing unit tests

### Where to look
New module `generate_scaling_factors`

### Usage Example/Visuals
```
>>> from prereise.gather.demanddata.transportation_electrification.generate_scaling_factors import census_ua_url, census_state_url, tht_data_url, load_census_ua, load_census_state, load_dot_vmt_per_capita, calculate_vmt_for_ua, calculate_vmt_for_state, calculate_urban_rural_fraction
>>> census_ua = load_census_ua(census_ua_url)
>>> census_state = load_census_state(census_state_url)
>>> tht_ua, tht_state = load_dot_vmt_per_capita(tht_data_url)
>>> vmt_ua = calculate_vmt_for_ua(census_ua, tht_ua)
>>> vmt_state = calculate_vmt_for_state(census_state, tht_state)
>>> vmt_ua_perc, vmt_ra_perc = calculate_urban_rural_fraction(vmt_ua, vmt_state)
>>> vmt_ra_perc
{'AL': 0.5948209907004509, 'AZ': 0.4072678991599876, 'AR': 0.6782718495006606, 'CA': 0.2522036919615287, 'CO': 0.4365774632878532, 'CT': 0.18269470942707955, 'DE': 0.559915703167249, 'DC': 0, 'FL': 0.2923051798349785, 'GA': 0.42402572834199637, 'ID': 0.6723734528747444, 'IL': 0.28372082436406665, 'IN': 0.5298558463320291, 'IA': 0.7022578956589101, 'KS': 0.5763025206199697, 'KY': 0.8477578601781653, 'LA': 0.5246373942279056, 'ME': 0.7882474490409153, 'MD': 0.3333401978676642, 'MA': 0.11947580340547559, 'MI': 0.3789053832349696, 'MN': 0.5432410752038628, 'MS': 0.7266752412880431, 'MO': 0.5071803635012153, 'MT': 0.8600569689974888, 'NE': 0.6739144929625285, 'NV': 0.399831570902325, 'NH': 0.6009439272679777, 'NJ': 0.33585021596160347, 'NM': 0.6848299106793774, 'NY': 0.19194166956193792, 'NC': 0.5092809432132339, 'ND': 0.8361712780525931, 'OH': 0.40514557017474595, 'OK': 0.5972732841621138, 'OR': 0.5636801026484732, 'PA': 0.3984935379624328, 'RI': 0.05679462197338614, 'SC': 0.588343323457865, 'SD': 0.8225877011609205, 'TN': 0.5049657185947951, 'TX': 0.4028581131849771, 'UT': 0.38149202467572874, 'VT': 0.8391650467810423, 'VA': 0.4227252560298854, 'WA': 0.364071745825326, 'WV': 0.7005357353635477, 'WI': 0.6074652247653839, 'WY': 0.8867296939626887}
>>> vmt_ua_perc["AL"]
Birmingham, AL         0.144348
Florence, AL           0.011524
Mobile, AL             0.060350
Pensacola, FL-AL       0.001210
Gadsden, AL            0.013453
Auburn, AL             0.013323
Montgomery, AL         0.049128
Decatur, AL            0.006910
Anniston-Oxford, AL    0.015453
Huntsville, AL         0.045015
Tuscaloosa, AL         0.021803
Dothan, AL             0.014312
Columbus, GA-AL        0.008350
Name: Annual VMT, dtype: float64
```

### Note
We will need to go over the data intake procedure for the input files

### Time estimate
20min
