### PR TITLE
Retrieve the projected annual VMT from NREL EFS 

### DIFF
--- a/prereise/gather/demanddata/nrel_efs/get_efs_annual_data.py
+++ b/prereise/gather/demanddata/nrel_efs/get_efs_annual_data.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+nrel_annual_efs_url = "https://data.nrel.gov/system/files/92/service_demand.csv.gzip"
+
+
+def get_efs_annual_data(path, sector):
+    """Download the electric technology service demand file from the NREL
+    Electrification Future Study (EFS) and return the electrification projection in
+    each state for a given sector
+
+    :param str path: path to electric technology service demand file from NREL EFS
+        (local or url)
+    :param str sector: sector to query in the file. Can be one of *'RESIDENTIAL'*,
+        *'COMMERCIAL'*, *'PRODUCTIVE'* (industrial) and *'TRANSPORTATION'*.
+    :return: (*pandas.DataFrame*) -- Columns are *'SCENARIO'* (range of electrification
+        futures, e.g. *'MEDIUM ELECTRIFICATION - MODERATE TECHNOLOGY ADVANCEMENT'*,
+        *'DEMAND_TECHNOLOGY'* (technologies for a given sector, e.g. *'ELECTRIC LIGHT-
+        DUTY AUTO - 100 MILE RANGE'* for transportation sector), *'STATE'* (50 United
+        States and District of Columbia), *'SUBSECTOR'* (a sub category of technology
+        for any sector, e.g. *'AVIATION'* of the transportation sector), *'YEAR'* (year
+        of projection), *'FINAL_ENERGY'* (type of energy, e.g. *'RESIDUAL FUEL
+        OIL'*), *'UNIT'* (unit of *'VALUE'*, e.g. *'MILE'*), *'VALUE'* (projected annual value).
+    :raises ValueError: if ``sector`` is invalid.
+    """
+    possible = ["RESIDENTIAL", "COMMERCIAL", "PRODUCTIVE", "TRANSPORTATION"]
+    if sector not in possible:
+        raise ValueError(f"invalid sector. Choose from {' | '.join(possible)}")
+
+    df = pd.read_csv(path, compression="gzip")
+
+    return df.query("SECTOR==@sector")[
+        [
+            "SCENARIO",
+            "SECTOR",
+            "DEMAND_TECHNOLOGY",
+            "STATE",
+            "SUBSECTOR",
+            "YEAR",
+            "FINAL_ENERGY",
+            "UNIT",
+            "VALUE",
+        ]
+    ]


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fetch NREL's Electrification Futures Study the transportation sector and build a data frame giving the VMT for a specified scenario and several technologies

### What the code is doing
Load data hosted by NREL, store data in memory as a data frame, filter the data frame and return the annual VMT for a user-specified scenario as a combination of year and vehicle type in each state 

### Testing
Existing unit tests

### Where to look
* one function load the data and return a data frame for a specified sector
* the other function returns a `dict` where keys are state abbreviations and values are data frames giving the miles traveled by a vehicle type (technology) in a given year for a user-specified range of electrification futures (scenario)

### Usage Example/Visuals
```
>>> from prereise.gather.demanddata.transportation_electrification.generate_scaling_factors import get_vmt_projection_for_state
>>> from prereise.gather.demanddata.nrel_efs.get_efs_annual_data import get_efs_annual_data, nrel_annual_efs_url
>>> efs = get_efs_annual_data(nrel_annual_efs_url, "TRANSPORTATION")
>>> vmt_projection = get_vmt_projection_for_state(efs)
>>> vmt_projection["CA"]
                              DEMAND_TECHNOLOGY  YEAR         VALUE
0          BATTERY ELECTRIC MEDIUM-DUTY VEHICLE  2017  1.935348e+07
1          BATTERY ELECTRIC MEDIUM-DUTY VEHICLE  2018  3.346116e+07
2          BATTERY ELECTRIC MEDIUM-DUTY VEHICLE  2019  5.122918e+07
3          BATTERY ELECTRIC MEDIUM-DUTY VEHICLE  2020  7.713368e+07
4          BATTERY ELECTRIC MEDIUM-DUTY VEHICLE  2021  1.135307e+08
..                                          ...   ...           ...
267  ELECTRIC LIGHT-DUTY TRUCK - 300 MILE RANGE  2046  3.263052e+10
268  ELECTRIC LIGHT-DUTY TRUCK - 300 MILE RANGE  2047  3.775862e+10
269  ELECTRIC LIGHT-DUTY TRUCK - 300 MILE RANGE  2048  4.318907e+10
270  ELECTRIC LIGHT-DUTY TRUCK - 300 MILE RANGE  2049  4.886458e+10
271  ELECTRIC LIGHT-DUTY TRUCK - 300 MILE RANGE  2050  5.471126e+10

[272 rows x 3 columns]
```
The 272 rows corresponds to 34 years [2017, 2050] and 8 technologies

### Time estimate
15min
