### PR TITLE
Fix call to function

### DIFF
--- a/prereise/gather/flexibilitydata/doe/bus_data.py
+++ b/prereise/gather/flexibilitydata/doe/bus_data.py
@@ -4,11 +4,11 @@ import pickle as pkl
 import re
 import time
 
-import geopy
 import numpy as np
 import pandas as pd
 import requests
 from geopy.extra.rate_limiter import RateLimiter
+from geopy.geocoders import Nominatim
 from powersimdata.utility.distance import find_closest_neighbor
 from tqdm import tqdm
 
@@ -22,20 +22,12 @@ def get_bus_pos(network_path):
 
     try:
         sub_df = pd.read_csv(os.path.join(network_path, "sub.csv"))
-    except Exception:
-        raise OSError(
-            errno.ENOENT,
-            os.strerror(errno.ENOENT),
-            "sub.csv in model folder does not exist.",
-        )
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Can't find sub.csv file in {network_path} folder")
     try:
         bus2sub_df = pd.read_csv(os.path.join(network_path, "bus2sub.csv"))
-    except Exception:
-        raise OSError(
-            errno.ENOENT,
-            os.strerror(errno.ENOENT),
-            "bus2sub.csv in model folder does not exist.",
-        )
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Can't find bus2sub.csv file in {network_path} folder")
 
     bus_pos = pd.DataFrame()
 
@@ -131,7 +123,7 @@ def get_bus_zip(bus_pos, cache_path, start_idx=0):
         "zip": [0] * bus_num,
     }
 
-    geocoder = geopy.Nominatim(user_agent="BES")
+    geocoder = Nominatim(user_agent="BES")
     reverse = RateLimiter(
         geocoder.reverse, min_delay_seconds=0.05, return_value_on_exception=None
     )

--- a/prereise/gather/flexibilitydata/doe/doe_data.py
+++ b/prereise/gather/flexibilitydata/doe/doe_data.py
@@ -49,12 +49,10 @@ def download_doe(download_path="data"):
     # delete and further extract
     os.remove(os.path.join(download_path, "filter.zip"))
 
-    for i in os.listdir(download_path):
-        fh = tarfile.open(os.path.join(download_path, i))
-        fh.extractall(download_path)
-
-        fh.close()
-        os.remove(os.path.join(download_path, i))
+    for f in os.listdir(download_path):
+        with tarfile.open(os.path.join(download_path, f), "r:gz") as fh:
+            fh.extractall(download_path)
+        os.remove(os.path.join(download_path, f))
 
     # cleanup
     cleanup_directory(download_path)

--- a/prereise/gather/flexibilitydata/doe/examples/bus_example.py
+++ b/prereise/gather/flexibilitydata/doe/examples/bus_example.py
@@ -7,11 +7,10 @@ from prereise.gather.flexibilitydata.doe.bus_data import (
     get_bus_zip,
 )
 
-case_path = "case.mat"
-cache_path = os.path.join("..", "cache")
+cache_path = os.path.join(os.path.dirname(__file__), os.pardir, "cache")
 
 # find coordinates of buses in a .mat case
-bus_pos = get_bus_pos(case_path, cache_path)
+bus_pos = get_bus_pos(cache_path)
 
 # find the FIPS of all buses and store to cache
 get_bus_fips(bus_pos, cache_path)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
What is the larger goal of this change?

### What the code is doing
Pass a single argument, the path to the folder containing the network data, to the `get_bus_pos` function. Some code responsible for reading files was refactored.

### Testing
An error was thrown when generating the documentation locally with `sphinx`. With the change, it is fixed.

### Where to look
The `get_bus_pos` located in the `prereise.gather.flexibilitydata.doe.bus_data` module takes one argument, the path to a folder containing the ***sub.csv*** and ***bus2sub.csv*** file. The `bus_example` script located in `prereise.gather.flexibilitydata.doe.examples.bus_example` module call the function with two arguments, the path to a folder and a filename.

@BainanXia and @lanesmith, do you know why the `get_bus_pos` reads network data instead of using a `Grid` object? A `Grid` object could be the argument of the `get_bus_pos` function.

### Usage Example/Visuals
N/A

### Time estimate
5min