### PR TITLE
Improve user experience

### DIFF
--- a/prereise/gather/flexibilitydata/doe/bus_data.py
+++ b/prereise/gather/flexibilitydata/doe/bus_data.py
@@ -13,34 +13,14 @@ from powersimdata.utility.distance import find_closest_neighbor
 from tqdm import tqdm
 
 
-def get_bus_pos(network_path):
+def get_bus_pos(grid):
     """Read raw files of synthetic grid and extract the lat/lon coordinate of all buses
 
-    :param str network_path: path to folder of raw data of a power network
-    :return: (*pandas.DataFrame*) -- (n x 3) dataframe containing bus coordinates
+    :param powersimdata.input.grid.Grid grid: a Grid instance
+    :return: (*pandas.DataFrame*) -- a data frame of bus position
     """
 
-    try:
-        sub_df = pd.read_csv(os.path.join(network_path, "sub.csv"))
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Can't find sub.csv file in {network_path} folder")
-    try:
-        bus2sub_df = pd.read_csv(os.path.join(network_path, "bus2sub.csv"))
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Can't find bus2sub.csv file in {network_path} folder")
-
-    bus_pos = pd.DataFrame()
-
-    bus_pos["bus_id"] = bus2sub_df["bus_id"]
-
-    bus_pos["lat"] = [
-        sub_df.loc[sub_df["sub_id"] == i, "lat"].values[0] for i in bus2sub_df["sub_id"]
-    ]
-    bus_pos["lon"] = [
-        sub_df.loc[sub_df["sub_id"] == i, "lon"].values[0] for i in bus2sub_df["sub_id"]
-    ]
-
-    return bus_pos
+    return grid.bus[["lat", "lon"]].reset_index()
 
 
 def get_bus_fips(bus_pos, cache_path, start_idx=0):

--- a/prereise/gather/flexibilitydata/doe/examples/bus_example.py
+++ b/prereise/gather/flexibilitydata/doe/examples/bus_example.py
@@ -1,5 +1,7 @@
 import os
 
+from powersimdata import Grid
+
 from prereise.gather.flexibilitydata.doe.bus_data import (
     get_all_bus_eiaid,
     get_bus_fips,
@@ -10,7 +12,8 @@ from prereise.gather.flexibilitydata.doe.bus_data import (
 cache_path = os.path.join(os.path.dirname(__file__), os.pardir, "cache")
 
 # find coordinates of buses in a .mat case
-bus_pos = get_bus_pos(cache_path)
+grid = Grid("Texas")
+bus_pos = get_bus_pos(grid)
 
 # find the FIPS of all buses and store to cache
 get_bus_fips(bus_pos, cache_path)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Use `Grid` object instead of ***sub.csv*** and ***bus2sub.csv*** files to get position of buses in network  

### What the code is doing
The `get_bus_pos` function is refactored. It takes a `Grid` object instead of a path to a directory enclosing the CSV files. The same data frame enclosing the coordinates of the buses in the network is returned. 

### Testing
```
>>> from prereise.gather.flexibilitydata.doe.bus_data import get_bus_pos
>>> from powersimdata import Grid
>>> grid = Grid("Texas")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> bus_pos = get_bus_pos(grid)
>>> bus_pos
       bus_id      lat       lon
0     3001001  31.9067 -102.2620
1     3001002  29.8880 -104.5190
2     3001003  32.9264 -101.6480
3     3001004  32.9264 -101.6480
4     3001005  32.2075 -101.3880
...       ...      ...       ...
1995  3008156  31.0919  -96.6950
1996  3008157  31.0919  -96.6950
1997  3008158  30.7217  -96.4608
1998  3008159  30.7217  -96.4608
1999  3008160  30.7217  -96.4608

[2000 rows x 3 columns]
```

### Where to look
The `prereise.gather.flexibilitydata.doe.bus_data` module where the `get_bus_pos` function is defined and the `prereise.gather.flexibilitydata.doe.examples.bus_example` module where the function is called

### Usage Example/Visuals
N/A

### Time estimate
How long will it take for reviewers and observers to understand this code change?
